### PR TITLE
Fix a hardware compatibility issue in ProcessDMA

### DIFF
--- a/DMA & PLCs/DMA.asm
+++ b/DMA & PLCs/DMA.asm
@@ -39,7 +39,7 @@ AddDMA:
 		move.w	(a2)+,(a1)+				; write source address
 		move.l	d2,(a1)+				; write length
 		move.l	d1,(a1)					; write destination address
-		
+
 	.not_found:
 		popr	d0/a1
 		rts
@@ -62,7 +62,7 @@ AddDMA2:
 		move.w	(a2)+,(a1)+				; write source address
 		move.l	(a2)+,(a1)+				; write length
 		move.l	d1,(a1)					; write destination address
-		
+
 	.not_found:
 		popr	d0/a1
 		rts
@@ -73,7 +73,7 @@ AddDMA2:
 ; output:
 ;	a6 = vdp_control_port
 
-;	uses d0.l, d1.l, d2.l, a1
+;	uses d0.l, d1.l, a1
 ; ---------------------------------------------------------------------------
 
 ProcessDMA:
@@ -85,16 +85,15 @@ ProcessDMA:
 	.loop:
 		tst.b	(a1)					; is DMA slot empty?
 		beq.s	.empty					; if yes, branch
-		move.l	(a1),(a6)				; write source address
+		move.l	(a1),(a6)				; write source address (high and mid)
 		move.l	d1,(a1)+				; delete from queue
-		move.w	(a1),(a6)				; write source address
+		move.l	(a1),(a6)				; write source address (low) and length (high)
+		move.l	d1,(a1)+
+		move.l	(a1),(a6)				; write length (low) and destination (high)
+		move.l	d1,(a1)+
+		move.w	(a1),(a6)				; write destination address (low)
 		move.w	d1,(a1)+
-		move.l	(a1),(a6)				; write length
-		move.l	d1,(a1)+
-		move.l	(a1),d2
-		move.l	d2,(a6)					; write destination address
-		move.l	d1,(a1)+
 		dbf	d0,.loop				; repeat for all DMA slots
-	
+
 	.empty:
 		rts


### PR DESCRIPTION
Among the various hardware bugs in the Model 1 VA0 (and possibly other revisions) is a bug in the DMA controller where, if the low word of the destination is written too slowly (such as from ROM) or is written to $C00006 (such as from writing the destination as a longword regardless of source), the DMA may trigger before the 68k finishes the write, causing corruption of VRAM, CRAM, or VSRAM contents. As such, to work correctly on all hardware, the low word of the destination must be a word write to $C00004 with RAM as the source (I suspect a data register would also work, but documentation only mentions RAM as a safe source; this is also the reason v_vdp_dma_buffer exists). However, everything else can be safely written as longwords, and there is no need to group the register writes by type.

To eliminate this issue, I've reworked the register write loop after the one used by Flamewings's Ultra DMA Queue. As a bonus, it no longer uses d2, and takes four fewer cycles per transfer. (If ROM space isn't an issue, it might be worthwhile to eventually replace the entire DMA system with Flamewing's Ultra DMA Queue, which uses an unrolled loop to do the transfers, but for moment, this fixes a significant issue with the current system.)