### PR TITLE
Addq/subq/moveq optimizations

### DIFF
--- a/Includes/DeformLayers.asm
+++ b/Includes/DeformLayers.asm
@@ -7,20 +7,20 @@
 DeformLayers:
 		tst.b	(f_disable_scrolling).w			; is scrolling disabled?
 		beq.s	.bgscroll				; if not, branch
-		rts	
+		rts
 ; ===========================================================================
 
 	.bgscroll:
-		clr.w	(v_fg_redraw_direction).w		; clear all redraw flags
-		clr.w	(v_bg1_redraw_direction).w
-		clr.w	(v_bg2_redraw_direction).w
-		clr.w	(v_bg3_redraw_direction).w
+		moveq	#0,d0
+		move.w	d0,(v_fg_redraw_direction).w		; clear all redraw flags
+		move.l	d0,(v_bg1_redraw_direction).w		; (also clears v_bg2_redraw_direction)
+		move.w	d0,(v_bg3_redraw_direction).w
 		bsr.w	UpdateCamera_X				; update camera position & redraw flags
 		bsr.w	UpdateCamera_Y
 		bsr.w	DynamicLevelEvents			; update level boundaries, load bosses etc.
 		move.w	(v_camera_y_pos).w,(v_fg_y_pos_vsram).w	; v_fg_y_pos_vsram is sent to VSRAM during VBlank
 		move.w	(v_bg1_y_pos).w,(v_bg_y_pos_vsram).w
-		
+
 		movea.l	(v_deformlayer_ptr).w,a1
 		jmp	(a1)
 
@@ -75,7 +75,7 @@ Deform_GHZ:
 		move.w	(v_bgscroll_buffer).w,d0		; get autoscroll position of upper cloud
 		add.w	(v_bg3_x_pos).w,d0			; add current bg position
 		neg.w	d0					; reverse
-		move.w	#32-1,d1
+		moveq	#32-1,d1
 		sub.w	d4,d1
 		bcs.s	.gotoCloud2
 	.cloudLoop1:						; upper cloud (32px)
@@ -86,7 +86,7 @@ Deform_GHZ:
 		move.w	(v_bgscroll_buffer+4).w,d0		; get autoscroll position of middle cloud
 		add.w	(v_bg3_x_pos).w,d0			; add current bg position
 		neg.w	d0					; reverse
-		move.w	#16-1,d1
+		moveq	#16-1,d1
 	.cloudLoop2:						; middle cloud (16px)
 		move.l	d0,(a1)+				; write to v_hscroll_buffer
 		dbf	d1,.cloudLoop2
@@ -94,13 +94,13 @@ Deform_GHZ:
 		move.w	(v_bgscroll_buffer+8).w,d0		; get autoscroll position of lower cloud
 		add.w	(v_bg3_x_pos).w,d0			; add current bg position
 		neg.w	d0					; reverse
-		move.w	#16-1,d1
+		moveq	#16-1,d1
 	.cloudLoop3:						; lower cloud (16px)
 		move.l	d0,(a1)+				; write to v_hscroll_buffer
 		dbf	d1,.cloudLoop3
 
 		; mountains
-		move.w	#48-1,d1
+		moveq	#48-1,d1
 		move.w	(v_bg3_x_pos).w,d0
 		neg.w	d0
 	.mountainLoop:						; distant mountains (48px)
@@ -108,7 +108,7 @@ Deform_GHZ:
 		dbf	d1,.mountainLoop
 
 		; hills and waterfalls
-		move.w	#40-1,d1
+		moveq	#40-1,d1
 		move.w	(v_bg2_x_pos).w,d0
 		neg.w	d0
 	.hillLoop:						; hills & waterfalls (40px)
@@ -126,7 +126,7 @@ Deform_GHZ:
 		asl.l	#8,d2
 		moveq	#0,d3
 		move.w	d0,d3
-		move.w	#72-1,d1
+		moveq	#72-1,d1
 		add.w	d4,d1
 	.waterLoop:
 		move.w	d3,d0
@@ -182,7 +182,7 @@ Deform_LZ:
 		move.w	(v_camera_y_pos).w,d5
 
 		; write normal scroll before meeting water position
-	.normalLoop:		
+	.normalLoop:
 		cmp.w	d4,d5					; is current scanline at or below actual water y pos?
 		bge.s	.underwaterLoop				; if yes, branch
 		move.l	d0,(a1)+				; write to v_hscroll_buffer without ripple effect
@@ -284,8 +284,8 @@ Deform_MZ:
 		moveq	#0,d3
 		move.w	d2,d3
 		asr.w	#1,d3
-		move.w	#4,d1
-	.cloudLoop:		
+		moveq	#5-1,d1
+	.cloudLoop:
 		move.w	d3,(a1)+
 		swap	d3
 		add.l	d0,d3
@@ -294,22 +294,22 @@ Deform_MZ:
 
 		move.w	(v_bg3_x_pos).w,d0
 		neg.w	d0
-		move.w	#1,d1
-	.mountainLoop:		
+		moveq	#2-1,d1
+	.mountainLoop:
 		move.w	d0,(a1)+
 		dbf	d1,.mountainLoop
 
 		move.w	(v_bg2_x_pos).w,d0
 		neg.w	d0
-		move.w	#8,d1
-	.bushLoop:		
+		moveq	#9-1,d1
+	.bushLoop:
 		move.w	d0,(a1)+
 		dbf	d1,.bushLoop
 
 		move.w	(v_bg1_x_pos).w,d0
 		neg.w	d0
-		move.w	#$F,d1
-	.interiorLoop:		
+		moveq	#16-1,d1
+	.interiorLoop:
 		move.w	d0,(a1)+
 		dbf	d1,.interiorLoop
 
@@ -354,8 +354,8 @@ Deform_SLZ_2:
 		asl.l	#8,d0
 		moveq	#0,d3
 		move.w	d2,d3
-		move.w	#28-1,d1
-	.starLoop:		
+		moveq	#28-1,d1
+	.starLoop:
 		move.w	d3,(a1)+
 		swap	d3
 		add.l	d0,d3
@@ -367,21 +367,21 @@ Deform_SLZ_2:
 		move.w	d0,d1
 		asr.w	#1,d1
 		add.w	d1,d0
-		move.w	#4,d1
+		moveq	#5-1,d1
 	.buildingLoop1:						; distant black buildings
 		move.w	d0,(a1)+
 		dbf	d1,.buildingLoop1
 
 		move.w	d2,d0
 		asr.w	#2,d0
-		move.w	#4,d1
+		moveq	#5-1,d1
 	.buildingLoop2:						; closer buildings
 		move.w	d0,(a1)+
 		dbf	d1,.buildingLoop2
 
 		move.w	d2,d0
 		asr.w	#1,d0
-		move.w	#30-1,d1
+		moveq	#30-1,d1
 	.bottomLoop:						; bottom part of background
 		move.w	d0,(a1)+
 		dbf	d1,.bottomLoop
@@ -407,7 +407,7 @@ Deform_SLZ_2:
 
 UpdateHscrollBuffer:
 		lea	(v_hscroll_buffer).w,a1
-		move.w	#$E,d1
+		moveq	#15-1,d1
 		move.w	(v_camera_x_pos).w,d0			; get camera x pos
 		neg.w	d0					; make negative
 		swap	d0					; move to high word
@@ -455,8 +455,8 @@ Deform_SYZ:
 		moveq	#0,d3
 		move.w	d2,d3
 		asr.w	#1,d3
-		move.w	#7,d1
-	.cloudLoop:		
+		moveq	#8-1,d1
+	.cloudLoop:
 		move.w	d3,(a1)+
 		swap	d3
 		add.l	d0,d3
@@ -465,15 +465,15 @@ Deform_SYZ:
 
 		move.w	d2,d0
 		asr.w	#3,d0
-		move.w	#4,d1
-	.mountainLoop:		
+		moveq	#5-1,d1
+	.mountainLoop:
 		move.w	d0,(a1)+
 		dbf	d1,.mountainLoop
 
 		move.w	d2,d0
 		asr.w	#2,d0
-		move.w	#5,d1
-	.buildingLoop:		
+		moveq	#6-1,d1
+	.buildingLoop:
 		move.w	d0,(a1)+
 		dbf	d1,.buildingLoop
 
@@ -490,8 +490,8 @@ Deform_SYZ:
 		moveq	#0,d3
 		move.w	d2,d3
 		asr.w	#1,d3
-		move.w	#$D,d1
-	.bushLoop:		
+		moveq	#14-1,d1
+	.bushLoop:
 		move.w	d3,(a1)+
 		swap	d3
 		add.l	d0,d3
@@ -568,8 +568,8 @@ Deform_SBZ1:
 		asl.l	#8,d0
 		moveq	#0,d3
 		move.w	d2,d3
-		move.w	#3,d1
-	.cloudLoop:		
+		moveq	#4-1,d1
+	.cloudLoop:
 		move.w	d3,(a1)+
 		swap	d3
 		add.l	d0,d3
@@ -578,21 +578,21 @@ Deform_SBZ1:
 
 		move.w	(v_bg3_x_pos).w,d0
 		neg.w	d0
-		move.w	#9,d1
+		moveq	#10-1,d1
 	.buildingLoop1:						; distant brown buildings
 		move.w	d0,(a1)+
 		dbf	d1,.buildingLoop1
 
 		move.w	(v_bg2_x_pos).w,d0
 		neg.w	d0
-		move.w	#6,d1
+		moveq	#7-1,d1
 	.buildingLoop2:						; upper black buildings
 		move.w	d0,(a1)+
 		dbf	d1,.buildingLoop2
 
 		move.w	(v_bg1_x_pos).w,d0
 		neg.w	d0
-		move.w	#$A,d1
+		moveq	#11-1,d1
 	.buildingLoop3:						; lower black buildings
 		move.w	d0,(a1)+
 		dbf	d1,.buildingLoop3
@@ -607,7 +607,7 @@ Deform_SBZ1:
 Deform_SBZ2:
 		; plain background deformation
 		move.w	(v_camera_x_diff).w,d4
-		ext.l	d4		
+		ext.l	d4
 		asl.l	#6,d4
 		move.w	(v_camera_y_diff).w,d5
 		ext.l	d5
@@ -617,13 +617,13 @@ Deform_SBZ2:
 
 		; copy fg & bg x position to hscroll table
 		lea	(v_hscroll_buffer).w,a1
-		move.w	#223,d1
+		move.w	#224-1,d1
 		move.w	(v_camera_x_pos).w,d0
 		neg.w	d0
 		swap	d0
 		move.w	(v_bg1_x_pos).w,d0
 		neg.w	d0
-	.loop_hscroll:		
+	.loop_hscroll:
 		move.l	d0,(a1)+
 		dbf	d1,.loop_hscroll
 		rts
@@ -648,7 +648,7 @@ UpdateCamera_X:
 		bpl.s	.scrollRight
 
 		bset	#redraw_left_bit,(v_fg_redraw_direction).w ; screen moves backward
-		rts	
+		rts
 
 	.scrollRight:
 		bset	#redraw_right_bit,(v_fg_redraw_direction).w ; screen moves forward
@@ -665,7 +665,7 @@ UCX_Camera:
 		subi.w	#16,d0					; is distance more than 160px?
 		bcc.s	UCX_AheadOfMid				; if yes, branch
 		clr.w	(v_camera_x_diff).w			; no camera movement
-		rts	
+		rts
 ; ===========================================================================
 
 UCX_AheadOfMid:
@@ -685,7 +685,7 @@ UCX_SetScreen:
 		asl.w	#8,d1					; move into high byte (multiply by $100)
 		move.w	d0,(v_camera_x_pos).w			; set new screen position
 		move.w	d1,(v_camera_x_diff).w			; set distance for camera movement
-		rts	
+		rts
 ; ===========================================================================
 
 UCX_BehindMid:
@@ -708,7 +708,7 @@ AutoScroll:
 		bra.s	UCX_BehindMid
 
 	.forwards:
-		move.w	#2,d0
+		moveq	#2,d0
 		bra.s	UCX_AheadOfMid
 
 ; ---------------------------------------------------------------------------
@@ -747,7 +747,7 @@ UpdateCamera_Y:
 
 .no_change:
 		clr.w	(v_camera_y_diff).w			; no camera movement
-		rts	
+		rts
 ; ===========================================================================
 
 UCY_OutsideMid_Ground:
@@ -863,7 +863,7 @@ UCY_SetScreen:
 		sub.w	d4,d0
 		bpl.s	.scrollBottom
 		bset	#redraw_top_bit,(v_fg_redraw_direction).w
-		rts	
+		rts
 ; ===========================================================================
 
 	.scrollBottom:

--- a/Includes/GM_Special.asm
+++ b/Includes/GM_Special.asm
@@ -229,7 +229,7 @@ PalCycle_SS:
 		mulu.w	#3,d0
 		lea	(a2,d0.w),a2				; jump to mappings source address
 		jsr	(AddDMA).w				; add mappings to DMA queue
-		suba.l	#6,a2					; jump back to same mappings
+		subq.l	#6,a2					; jump back to same mappings
 		add.l	#$800<<16,d1				; add $800 to VRAM address
 		jsr	(AddDMA).w				; add mappings to DMA queue again
 

--- a/Objects/GHZ Bridge.asm
+++ b/Objects/GHZ Bridge.asm
@@ -41,7 +41,7 @@ Bri_Main:	; Routine 0
 		
 		sub.w	ost_x_pos(a0),d1
 		neg.w	d1					; d1 = x pos of left edge
-		addi.w	#8,d1
+		addq.w	#8,d1
 		subq.b	#1,d2
 		move.b	d2,ost_bridge_last_log(a0)		; save id of rightmost log
 		moveq	#0,d3

--- a/Objects/GHZ, MZ & SLZ Swinging Platforms, SBZ Ball on Chain.asm
+++ b/Objects/GHZ, MZ & SLZ Swinging Platforms, SBZ Ball on Chain.asm
@@ -161,7 +161,7 @@ Swing_Main:	; Routine 0
 		bsr.w	FindFreeSub				; find free subsprite table
 		bne.s	Swing_Anchor
 		move.w	d1,(a1)+				; write subsprite count
-		subi.b	#1,d1					; subtract 1 for loops
+		subq.b	#1,d1					; subtract 1 for loops
 	.loop:
 		move.w	#sprite2x2,(a1)+			; write y pos (blank) & sprite size
 		move.w	ost_tile(a0),d0				; tile setting from anchor

--- a/Objects/HUD Debug Overlay.asm
+++ b/Objects/HUD Debug Overlay.asm
@@ -114,7 +114,7 @@ Overlay_Sonic:	; Routine 2
 		cmpi.b	#id_Duck,ost_anim(a1)
 		bne.s	Overlay_ShowBox				; branch if Sonic isn't ducking
 		moveq	#6,d5					; hitbox is 6px lower
-		subi.b	#6,d0					; smaller hitbox when ducking
+		subq.b	#6,d0					; smaller hitbox when ducking
 		
 Overlay_ShowBox:
 		move.w	#5,(a2)

--- a/Objects/LZ Door Horizontal.asm
+++ b/Objects/LZ Door Horizontal.asm
@@ -16,7 +16,7 @@ DoorH_Index:	index *,,2
 		ptr DoorH_Solid
 		ptr DoorH_ChkBtn
 		ptr DoorH_Move
-		
+
 		rsobj LabyrinthDoorH
 ost_doorh_x_start:	rs.w 1					; initial x pos
 ost_doorh_x_open:	rs.w 1					; open x pos
@@ -34,12 +34,12 @@ DoorH_Main:	; Routine 0
 		move.b	#16,ost_height(a0)
 		move.w	ost_x_pos(a0),ost_doorh_x_start(a0)
 		move.w	#128,d1
-		
+
 		btst	#status_xflip_bit,ost_status(a0)
 		beq.s	.no_xflip				; branch if not xflipped
 		add.w	#128,ost_x_pos(a0)			; move into open position
 		move.w	#-128,d1
-		
+
 	.no_xflip:
 		bsr.w	GetState
 		bne.s	DoorH_Solid				; branch if already opened
@@ -62,7 +62,7 @@ DoorH_ChkBtn:	; Routine 4
 		bsr.w	SaveState
 		beq.s	.not_found				; branch if not in respawn table
 		bset	#0,(a2)					; remember door state
-		
+
 	.not_found:
 		addq.b	#2,ost_routine(a0)			; goto DoorH_Move next
 
@@ -72,18 +72,18 @@ DoorH_Move:	; Routine 6
 		beq.s	.no_xflip				; branch if not xflipped
 		cmp.w	ost_doorh_x_open(a0),d0
 		bge.s	.fully_open				; branch if door is fully open
-		addi.w	#2,d0					; move right 2px
+		addq.w	#2,d0					; move right 2px
 		move.w	d0,ost_x_pos(a0)			; update x pos
 		bra.s	DoorH_Solid
-		
+
 	.no_xflip:
 		cmp.w	ost_doorh_x_open(a0),d0
 		ble.s	.fully_open				; branch if door is fully open
-		subi.w	#2,d0					; move left 2px
+		subq.w	#2,d0					; move left 2px
 		move.w	d0,ost_x_pos(a0)			; update x pos
 		bra.s	DoorH_Solid
-		
+
 	.fully_open:
 		move.b	#id_DoorH_Solid,ost_routine(a0)		; goto DoorH_Solid next
 		bra.s	DoorH_Solid
-		
+

--- a/Objects/LZ Door Vertical.asm
+++ b/Objects/LZ Door Vertical.asm
@@ -71,7 +71,7 @@ DoorV_Move:	; Routine 6
 		move.w	ost_y_pos(a0),d0
 		cmp.w	ost_doorv_y_start(a0),d0
 		ble.s	.fully_open				; branch if door is fully open
-		subi.w	#2,d0					; move up 2px
+		subq.w	#2,d0					; move up 2px
 		move.w	d0,ost_y_pos(a0)			; update y pos
 		bra.s	DoorV_Solid
 		

--- a/Objects/LZ Gargoyle Head.asm
+++ b/Objects/LZ Gargoyle Head.asm
@@ -37,7 +37,7 @@ Gar_Main:	; Routine 0
 		move.b	#$10,ost_displaywidth(a0)
 		move.b	ost_subtype(a0),d0			; get object type
 		andi.w	#$F,d0					; read only the	low nybble
-		addi.b	#1,d0
+		addq.b	#1,d0
 		mulu.w	#30,d0
 		move.b	d0,ost_gar_time_master(a0)		; set fireball spit rate
 		move.b	ost_gar_time_master(a0),ost_anim_time(a0)

--- a/Objects/LZ Half Block.asm
+++ b/Objects/LZ Half Block.asm
@@ -63,7 +63,7 @@ HBlock_Move:	; Routine 6
 		move.w	ost_x_pos(a0),ost_x_prev(a0)
 		btst	#status_xflip_bit,ost_status(a0)
 		beq.s	.noxflip				; branch if not xflipped
-		subi.w	#1,ost_x_pos(a0)			; move 1px left
+		subq.w	#1,ost_x_pos(a0)			; move 1px left
 		bsr.w	SolidObject_TopOnly
 		bsr.w	FindWallLeftObj
 		tst.w	d1
@@ -71,7 +71,7 @@ HBlock_Move:	; Routine 6
 		bra.w	DespawnQuick
 		
 	.noxflip:
-		addi.w	#1,ost_x_pos(a0)			; move 1px right
+		addq.w	#1,ost_x_pos(a0)			; move 1px right
 		bsr.w	SolidObject_TopOnly
 		bsr.w	FindWallRightObj
 		tst.w	d1

--- a/Objects/MZ Pushable Blocks.asm
+++ b/Objects/MZ Pushable Blocks.asm
@@ -83,7 +83,7 @@ PushB_Action:	; Routine 2
 		jsr	FindFloorObj
 		tst.w	d1
 		beq.w	DespawnObject				; branch if block is touching the floor
-		addi.b	#2,ost_routine(a0)			; goto PushB_Drop next
+		addq.b	#2,ost_routine(a0)			; goto PushB_Drop next
 		move.b	ost_pblock_pushed(a0),d0
 		ext.w	d0
 		add.w	d0,ost_x_pos(a0)			; align with edge if pushed
@@ -94,7 +94,7 @@ PushB_Drop:	; Routine 4
 		;bsr.w	SolidObject
 		bsr.w	PushB_ChkStomp
 		bne.s	.gravity				; branch if block isn't on stomper
-		subi.b	#2,ost_routine(a0)			; goto PushB_Action next
+		subq.b	#2,ost_routine(a0)			; goto PushB_Action next
 		bra.w	DespawnObject
 		
 	.gravity:
@@ -104,7 +104,7 @@ PushB_Drop:	; Routine 4
 		bpl.w	DespawnObject				; branch if block hasn't reached floor
 		add.w	d1,ost_y_pos(a0)			; align to floor
 		clr.w	ost_y_vel(a0)				; stop falling
-		subi.b	#2,ost_routine(a0)			; goto PushB_Action next
+		subq.b	#2,ost_routine(a0)			; goto PushB_Action next
 		move.w	(a3),d0					; get 16x16 tile the block is on
 		andi.w	#$3FF,d0
 		cmpi.w	#$16A,d0				; is it block $16A+ (lava)?
@@ -163,7 +163,7 @@ PushB_WaitJump:	; Routine $A
 		cmpi.b	#id_Fount_Make,ost_routine(a1)
 		bne.w	PushB_Move				; branch if geyser is inactive
 		move.w	#-$580,ost_y_vel(a0)			; make block jump
-		addi.b	#2,ost_routine(a0)			; goto PushB_Jump next
+		addq.b	#2,ost_routine(a0)			; goto PushB_Jump next
 		clr.w	ost_linked(a0)
 		bra.w	PushB_Move
 ; ===========================================================================
@@ -284,7 +284,7 @@ PushB_ChkGeyser:
 		lea	GeyserList(pc,d0.w),a2			; read from relevant list of x coords
 		move.w	(a2)+,d1				; get count of x coords
 		beq.s	.exit					; branch if 0
-		subi.w	#1,d1					; subtract 1 for loops
+		subq.w	#1,d1					; subtract 1 for loops
 		
 	.loop:
 		move.w	(a2)+,d0

--- a/Objects/SBZ Conveyor Belt Platforms.asm
+++ b/Objects/SBZ Conveyor Belt Platforms.asm
@@ -88,7 +88,7 @@ ost_spinc_corner_count:	equ __rs-1				; total number of corners +1, times 4
 ; ===========================================================================
 
 SpinCP_Main:	; Routine 0
-		addi.b	#2,ost_routine(a0)			; goto SpinCP_Solid next
+		addq.b	#2,ost_routine(a0)			; goto SpinCP_Solid next
 		move.l	#Map_Spin,ost_mappings(a0)
 		move.w	#tile_Kos_SpinPlatform,ost_tile(a0)
 		move.b	#$10,ost_displaywidth(a0)

--- a/Objects/SLZ Seesaw.asm
+++ b/Objects/SLZ Seesaw.asm
@@ -44,7 +44,7 @@ See_Main:	; Routine 0
 		move.w	ost_x_pos(a0),ost_x_pos(a1)
 		addi.w	#$28,ost_x_pos(a1)			; move spikeball to right side
 		move.w	ost_y_pos(a0),ost_y_pos(a1)
-		subi.w	#8,ost_y_pos(a1)
+		subq.w	#8,ost_y_pos(a1)
 		move.b	ost_status(a0),ost_status(a1)
 		move.l	#Map_SSawBall,ost_mappings(a1)
 		move.w	#tile_Kos_SlzSpike,ost_tile(a1)
@@ -155,7 +155,7 @@ See_BallAir:	; Routine 6
 		subq.b	#2,ost_routine(a0)			; goto See_Ball next
 		move.w	ost_x_pos(a1),ost_x_pos(a0)
 		move.w	ost_y_pos(a1),ost_y_pos(a0)		; reset position to match seesaw
-		subi.w	#8,ost_y_pos(a0)
+		subq.w	#8,ost_y_pos(a0)
 		move.b	#id_frame_seesaw_sloping_leftup,ost_frame(a1)
 		cmpi.b	#1,ost_subtype(a0)
 		beq.s	.from_left				; branch if spikeball is coming from the left side

--- a/Objects/SYZ Blocks at Boss.asm
+++ b/Objects/SYZ Blocks at Boss.asm
@@ -48,7 +48,7 @@ BBlock_Main:	; Routine 0
 		move.w	#$582,ost_y_pos(a1)
 		move.b	d4,ost_subtype(a1)			; blocks have subtypes 0-9
 		move.b	d4,ost_bblock_mode(a1)
-		addi.w	#1,d4					; increment subtype
+		addq.w	#1,d4					; increment subtype
 		addi.w	#$20,d5					; +32px for next x position
 		addq.b	#2,ost_routine(a1)			; goto BBlock_Action next
 		dbf	d6,.loop				; repeat sequence 9 more times

--- a/Objects/_FindFloorObj, FindWallRightObj, FindCeilingObj & FindWallLeftObj.asm
+++ b/Objects/_FindFloorObj, FindWallRightObj, FindCeilingObj & FindWallLeftObj.asm
@@ -35,7 +35,7 @@ FindFloorObj2:
 		move.b	#0,d3					; snap to flat floor
 
 	.no_snap:
-		addi.w	#1,d1
+		addq.w	#1,d1
 		rts
 		
 SnapFloor:


### PR DESCRIPTION
Went through the code and performed every possible addq and subq optimization that I could find. I also did a bunch of moveq optimizations in DeformLayers (mostly the instructions that set up the loop counters), and reduced the redraw flag clear process by 20 cycles (the clr instruction is best used when clearing one or two individual operands since it reads the destination before zeroing it).