### PR TITLE
Many addq/subq/moveq/clr/tst optimizations

### DIFF
--- a/Includes/AnimateLevelGfx.asm
+++ b/Includes/AnimateLevelGfx.asm
@@ -46,7 +46,7 @@ AniArt_Run:
 		jsr	(AddDMA).w				; add to DMA queue
 
 	.next:
-		lea	4(a4),a4				; next time/frame counter in RAM
+		addq.w	#4,a4				; next time/frame counter in RAM
 		dbf	d4,.loop				; repeat for all scripts
 		rts
 

--- a/Includes/GM_Credits.asm
+++ b/Includes/GM_Credits.asm
@@ -65,7 +65,7 @@ Cred_TryAgain:
 
 EndDemoSetup:
 		move.w	(v_credits_num).w,d0			; get credits id
-		add.w	#countof_demo,d0			; convert to demo id
+		addq.w	#countof_demo,d0			; convert to demo id
 		move.w	d0,(v_demo_num).w
 		jsr	LoadPerDemo
 		addq.w	#1,(v_credits_num).w			; increment credits number

--- a/Includes/GM_HiddenCredits.asm
+++ b/Includes/GM_HiddenCredits.asm
@@ -23,7 +23,7 @@ GM_HiddenCredits:
 		locVRAM	vram_fg,d0				; foreground, x=0, y=0
 		moveq	#$28,d1					; width
 		moveq	#$1C,d2					; height
-		move.w	#0,d3					; tile setting
+		moveq	#0,d3					; tile setting
 		bsr.w	LoadTilemap
 
 		lea	(v_pal_dry).w,a1

--- a/Includes/GM_Special.asm
+++ b/Includes/GM_Special.asm
@@ -229,7 +229,7 @@ PalCycle_SS:
 		lea	(a2,d0.w),a2				; jump to mappings source address
 		jsr	(AddDMA).w				; add mappings to DMA queue
 		subq.l	#6,a2					; jump back to same mappings
-		add.l	#$800<<16,d1				; add $800 to VRAM address
+		addi.l	#$800<<16,d1				; add $800 to VRAM address
 		jsr	(AddDMA).w				; add mappings to DMA queue again
 
 		move.w	#$8400,d0				; VDP register - bg nametable address
@@ -975,7 +975,7 @@ SS_Load:
 
 	.ss_valid:
 		move.l	(v_emeralds).w,d1
-		cmp.l	#emerald_all,d1				; do you have all emeralds?
+		cmpi.l	#emerald_all,d1				; do you have all emeralds?
 		beq.s	SS_LoadData				; if yes, branch
 		btst	d0,d1					; check if emerald has been collected for specific level
 		bne.s	SS_Load					; branch if yes (increment level counter until uncollected emerald is found)
@@ -1119,6 +1119,6 @@ SS_Item_Glass6:	ss_sprite Map_SS_Glass,tile_Kos_SSGlass+tile_pal4,0 ; $4C
 SS_Item_Glass7:	ss_sprite Map_SS_Glass,tile_Kos_SSGlass+tile_pal2,0 ; $4D
 SS_Item_Glass8:	ss_sprite Map_SS_Glass,tile_Kos_SSGlass+tile_pal3,0 ; $4E
 	SS_ItemIndex_end:
-	
+
 tile_Kos_Bumper_KPLC_Special: equ 0
 tile_Kos_Ring_KPLC_Special: equ 0

--- a/Includes/GM_Title.asm
+++ b/Includes/GM_Title.asm
@@ -22,7 +22,7 @@ GM_Title:
 		bsr.w	ClearRAM				; fill OST with 0
 
 		lea	(v_pal_dry).w,a1
-		move.w	#loops_to_clear_pal,d1
+		moveq	#loops_to_clear_pal,d1
 		bsr.w	ClearRAM
 
 		moveq	#id_Pal_Sonic,d0			; load Sonic's palette
@@ -33,18 +33,19 @@ GM_Title:
 		bsr.w	BuildSprites
 		bsr.w	PaletteFadeIn				; fade in to "SONIC TEAM PRESENTS" screen from black
 		moveq	#id_VBlank_Title,d1
-		move.w	#60,d0
+		moveq	#60,d0
 		bsr.w	WaitLoop				; freeze for 1 second
 		disable_ints
 
-		move.b	#0,(v_last_lamppost).w			; clear lamppost counter
-		move.w	#0,(v_debug_active).w			; disable debug item placement mode
-		move.w	#0,(v_demo_mode).w			; disable debug mode
+		moveq	#0,d0
+		move.b	d0,(v_last_lamppost).w			; clear lamppost counter
+		move.w	d0,(v_debug_active).w			; disable debug item placement mode
+		move.w	d0,(v_demo_mode).w			; disable debug mode
 		move.w	#id_GHZ_act1,(v_zone).w			; set level to GHZ act 1 (0000)
-		move.w	#0,(v_palcycle_time).w			; disable palette cycling
+		move.w	d0,(v_palcycle_time).w			; disable palette cycling
 		bsr.w	PaletteFadeOut				; fade out "SONIC TEAM PRESENTS" screen to black
 		moveq	#id_SPLC_Title,d0
-		jsr	SlowPLC_Now				; load title screen gfx
+		jsr	SlowPLC_Now			; load title screen gfx
 		bsr.w	LoadPerZone
 		bsr.w	LevelParameterLoad			; set level boundaries and Sonic's start position
 		bsr.w	DeformLayers
@@ -70,7 +71,7 @@ GM_Title:
 		moveq	#id_Pal_Title,d0			; load title screen palette
 		bsr.w	PalLoad
 		play.b	1, jsr, mus_TitleScreen			; play title screen music
-		move.b	#0,(f_debug_enable).w			; disable debug mode
+		clr.b	(f_debug_enable).w			; disable debug mode
 		move.w	#406,(v_countdown).w			; run title screen for 406 frames
 
 		jsr	FindFreeInert
@@ -93,7 +94,7 @@ GM_Title:
 		bsr.w	ExecuteObjects
 		bsr.w	DeformLayers
 		bsr.w	BuildSprites
-		move.w	#0,(v_title_d_count).w			; reset d-pad counter
+		clr.w	(v_title_d_count).w			; reset d-pad counter
 		enable_display
 		bsr.w	PaletteFadeIn				; fade in to title screen from black
 
@@ -160,7 +161,7 @@ LevSel_Init:
 		move.w	#loops_to_clear_hscroll,d1
 		bsr.w	ClearRAM				; clear hscroll buffer (in RAM)
 
-		move.l	#0,(v_fg_y_pos_vsram).w
+		clr.l	(v_fg_y_pos_vsram).w
 		disable_ints
 
 		locVRAM	vram_bg,d0
@@ -251,62 +252,62 @@ LevSel_Hold:
 		rts
 
 LevSel_Down:
-		add.w	#1,d0					; goto next item
-		cmp.w	#linecount,d0
+		addq.w	#1,d0					; goto next item
+		cmpi.w	#linecount,d0
 		bne.s	.exit					; branch if item is valid
 		moveq	#0,d0					; jump to start after last item
 	.exit:
 		rts
 
 LevSel_Up:
-		sub.w	#1,d0					; goto previous item
+		subq.w	#1,d0					; goto previous item
 		bpl.s	.exit					; branch if item is valid
-		move.w	#linecount-1,d0				; jump to end before first item
+		moveq	#linecount-1,d0				; jump to end before first item
 	.exit:
 		rts
 
 LevSel_Right:
-		cmp.w	#linesound,d0
+		cmpi.w	#linesound,d0
 		bne.s	.not_soundtest				; branch if not on sound test
-		add.w	#1,(v_levelselect_sound).w		; increment sound test
-		cmp.w	#$50,(v_levelselect_sound).w
+		addq.w	#1,(v_levelselect_sound).w		; increment sound test
+		cmpi.w	#$50,(v_levelselect_sound).w
 		bne.s	.exit					; branch if valid
-		move.w	#0,(v_levelselect_sound).w		; reset to 0 if above max
+		clr.w	(v_levelselect_sound).w		; reset to 0 if above max
 		bra.s	.exit
 	.not_soundtest:
-		cmp.w	#linecharsel,d0
+		cmpi.w	#linecharsel,d0
 		bne.s	.not_charsel				; branch if not on character select
-		add.w	#1,(v_character1).w			; increment character select
-		cmp.w	#3,(v_character1).w
+		addq.w	#1,(v_character1).w			; increment character select
+		cmpi.w	#3,(v_character1).w
 		bne.s	.exit					; branch if valid
-		move.w	#0,(v_character1).w			; reset to 0 if above max
+		clr.w	(v_character1).w			; reset to 0 if above max
 		bra.s	.exit
 	.not_charsel:
-		add.w	#linecolumn,d0				; goto next column
-		cmp.w	#linecount,d0
+		addi.w	#linecolumn,d0				; goto next column
+		cmpi.w	#linecount,d0
 		blt.s	.exit					; branch if item is valid
-		sub.w	#linecolumn,d0				; undo
+		subi.w	#linecolumn,d0				; undo
 	.exit:
 		rts
 
 LevSel_Left:
-		cmp.w	#linesound,d0
+		cmpi.w	#linesound,d0
 		bne.s	.not_soundtest				; branch if not on sound test
-		sub.w	#1,(v_levelselect_sound).w		; increment sound test
+		subq.w	#1,(v_levelselect_sound).w		; increment sound test
 		bpl.s	.exit					; branch if valid
 		move.w	#$4F,(v_levelselect_sound).w		; jump to $4F if below 0
 		bra.s	.exit
 	.not_soundtest:
-		cmp.w	#linecharsel,d0
+		cmpi.w	#linecharsel,d0
 		bne.s	.not_charsel				; branch if not on character select
-		sub.w	#1,(v_character1).w			; increment character select
+		subq.w	#1,(v_character1).w			; increment character select
 		bpl.s	.exit					; branch if valid
 		move.w	#2,(v_character1).w			; jump to 2 if below 0
 		bra.s	.exit
 	.not_charsel:
-		sub.w	#linecolumn,d0				; goto previous column
+		subi.w	#linecolumn,d0				; goto previous column
 		bpl.s	.exit					; branch if item is valid
-		add.w	#linecolumn,d0				; undo
+		addi.w	#linecolumn,d0				; undo
 	.exit:
 		rts
 
@@ -316,20 +317,20 @@ LevSel_Display:
 		lea	(vdp_control_port).l,a6
 		locVRAM	vram_bg+linestart,d3
 		move.l	d3,d4
-		move.w	#linecount-1,d0
+		moveq	#linecount-1,d0
 		moveq	#0,d5
 		moveq	#0,d6
 
 	.loop:
 		move.l	d3,(a6)
 		bsr.w	LevSel_Line				; draw line of text
-		lea	6(a1),a1				; next string
+		addq.w	#6,a1				; next string
 		addi.l	#sizeof_vram_row<<16,d3			; jump to next line in nametable
-		add.w	#1,d5					; count line number in current column
-		add.w	#1,d6					; count line number overall
-		cmp.w	#linecolumn,d5
+		addq.w	#1,d5					; count line number in current column
+		addq.w	#1,d6					; count line number overall
+		cmpi.w	#linecolumn,d5
 		bne.s	.not_last				; branch if not last line in column
-		add.l	#(columnwidth*2)<<16,d4			; jump to next column
+		addi.l	#(columnwidth*2)<<16,d4			; jump to next column
 		move.l	d4,d3					; update drawing position
 		moveq	#0,d5
 
@@ -338,42 +339,42 @@ LevSel_Display:
 		rts
 
 LevSel_Line:
-		move.w	#linesize-1,d1
+		moveq	#linesize-1,d1
 
 	.loop:
 		moveq	#0,d2
 		move.b	(a1)+,d2				; get character
-		cmp.w	#linesound,d6				; d6 = current line being drawn
+		cmpi.w	#linesound,d6				; d6 = current line being drawn
 		bne.s	.not_soundtest				; branch if not the sound test
-		cmp.w	#1,d1
+		cmpi.w	#1,d1
 		bgt.s	.not_soundtest				; branch if not the last 2 characters on the line
 		move.w	(v_levelselect_sound).w,d2		; get current sound test
-		add.b	#$80,d2
+		addi.b	#$80,d2
 		lsl.w	#2,d1					; multiply character number by 4 (so it's either 4 or 0)
 		lsr.b	d1,d2					; move high nybble to low if d1 is 4
-		and.b	#$F,d2					; read single nybble
-		add.b	#$30,d2					; convert to character
+		andi.b	#$F,d2					; read single nybble
+		addi.b	#$30,d2					; convert to character
 		lsr.w	#2,d1					; restore d1
 
 	.not_soundtest:
-		cmp.w	#linecharsel,d6				; d6 = current line being drawn
+		cmpi.w	#linecharsel,d6				; d6 = current line being drawn
 		bne.s	.not_charsel				; branch if not the character select
-		cmp.w	#charselsize-1,d1
+		cmpi.w	#charselsize-1,d1
 		bgt.s	.not_charsel				; branch if not the last 8 characters on the line
 		move.w	(v_character1).w,d2			; get character id
 		lsl.w	#3,d2					; multiply by 8
-		sub.w	#charselsize-1,d1
+		subi.w	#charselsize-1,d1
 		neg.w	d1					; invert value d1
 		add.w	d1,d2					; add d1
 		neg.w	d1
-		add.w	#charselsize-1,d1			; restore d1
+		addi.w	#charselsize-1,d1			; restore d1
 		move.b	(a2,d2.w),d2				; get character
 
 	.not_charsel:
-		add.w	#tile_Kos_Text+tile_pal4+tile_hi-$20,d2	; convert to tile
+		addi.w	#tile_Kos_Text+tile_pal4+tile_hi-$20,d2	; convert to tile
 		cmp.w	(v_levelselect_item).w,d6		; d6 = current line being drawn
 		bne.s	.unselected				; branch if line is not selected
-		sub.w	#$2000,d2				; use yellow text
+		subi.w	#$2000,d2				; use yellow text
 
 	.unselected:
 		move.w	d2,-4(a6)				; write to nametable in VRAM
@@ -387,13 +388,13 @@ LevSel_Select:
 		lea	LevSel_Strings(pc),a1
 		move.w	(v_levelselect_item).w,d1
 		mulu.w	#linesize+6,d1
-		add.w	#linesize,d1
+		addi.w	#linesize,d1
 		lea	(a1,d1.w),a1				; jump to data after string for current line
 		move.w	(a1)+,d2				; get item type
 		add.w	d2,d2
 		move.w	LevSel_Index(pc,d2.w),d2
 		jsr	LevSel_Index(pc,d2.w)
-		cmp.w	#linesound,(v_levelselect_item).w
+		cmpi.w	#linesound,(v_levelselect_item).w
 		beq.s	.nothing				; don't exit if on the sound test
 		moveq	#1,d0					; set flag to exit level select
 		rts
@@ -468,10 +469,10 @@ LevSel_Credits:
 LevSel_Sound:
 		btst.b	#bitA,(v_joypad_press_actual).w		; is button A pressed?
 		beq.s	.play					; branch if not
-		add.w	#$10,(v_levelselect_sound).w		; skip $10
-		cmp.w	#$4F,(v_levelselect_sound).w
+		addi.w	#$10,(v_levelselect_sound).w		; skip $10
+		cmpi.w	#$4F,(v_levelselect_sound).w
 		ble.s	.exit					; branch if valid
-		move.w	#0,(v_levelselect_sound).w		; reset to 0
+		clr.w	(v_levelselect_sound).w		; reset to 0
 	.exit:
 		bra.w	LevSel_Display				; update number
 
@@ -490,7 +491,7 @@ PlayDemo:
 		addq.w	#1,(v_demo_num).w			; add 1 to demo number
 		cmpi.w	#countof_demo,(v_demo_num).w		; is demo number less than 4?
 		blo.s	.demo_0_to_3				; if yes, branch
-		move.w	#0,(v_demo_num).w			; reset demo number to 0
+		clr.w	(v_demo_num).w			; reset demo number to 0
 
 	.demo_0_to_3:
 		move.w	#1,(v_demo_mode).w			; turn demo mode on

--- a/Includes/LoadTilemap.asm
+++ b/Includes/LoadTilemap.asm
@@ -30,7 +30,7 @@ LoadTilemap:
 		add.w	d3,d4					; apply tile setting
 		move.w	d4,(a2)					; write value to nametable
 		dbf	d5,.loop_cell				; next tile
-		add.l	#sizeof_vram_row<<16,d0			; goto next line (add $800000)
+		addi.l	#sizeof_vram_row<<16,d0			; goto next line (add $800000)
 		dbf	d2,.loop_row				; next line
 		rts
 		

--- a/Includes/ObjPosLoad.asm
+++ b/Includes/ObjPosLoad.asm
@@ -52,7 +52,7 @@ OPL_Init:
 		addq.b	#1,(a2)					; increment respawn list counter
 
 	.no_respawn:
-		add.w	#10,a0					; goto next object in objpos list
+		addi.w	#10,a0					; goto next object in objpos list
 		bra.s	.loop_find_right_init			; loop until object is found within window
 ; ===========================================================================
 
@@ -70,7 +70,7 @@ OPL_Init:
 		addq.b	#1,1(a2)				; increment second respawn list counter
 
 	.no_respawn2:
-		add.w	#10,a0					; goto next object in objpos list
+		addi.w	#10,a0					; goto next object in objpos list
 		bra.s	.loop_find_left_init			; loop until object is found within window
 ; ===========================================================================
 
@@ -96,7 +96,7 @@ OPL_MovedLeft:
 .loop_find_left:
 		cmp.w	-10(a0),d6				; read objpos backwards
 		bge.s	.found_left				; branch if object is outside spawn window
-		sub.w	#10,a0					; update pointer
+		subi.w	#10,a0					; update pointer
 		tst.b	4(a0)					; 4(a0) = remember state flag
 		bpl.s	.no_respawn				; branch if no remember flag found
 		subq.b	#1,1(a2)				; decrement second respawn list counter
@@ -105,7 +105,7 @@ OPL_MovedLeft:
 	.no_respawn:
 		bsr.w	OPL_SpawnObj				; check respawn flag and spawn object
 		bne.s	.fail					; branch if spawn fails
-		sub.w	#10,a0					; goto previous object in objpos list
+		subi.w	#10,a0					; goto previous object in objpos list
 		bra.s	.loop_find_left				; loop until object is found within window
 ; ===========================================================================
 
@@ -115,7 +115,7 @@ OPL_MovedLeft:
 		addq.b	#1,1(a2)
 
 	.no_respawn2:
-		add.w	#10,a0
+		addi.w	#10,a0
 
 .found_left:
 		move.l	a0,(v_opl_ptr_left).w			; save pointer for objpos
@@ -130,7 +130,7 @@ OPL_MovedLeft:
 		subq.b	#1,(a2)					; decrement respawn list counter
 
 	.no_respawn3:
-		sub.w	#10,a0					; goto previous object in objpos list
+		subi.w	#10,a0					; goto previous object in objpos list
 		bra.s	.loop_find_right
 ; ===========================================================================
 
@@ -170,7 +170,7 @@ OPL_MovedRight:
 		addq.b	#1,1(a2)
 
 	.no_respawn2:
-		add.w	#10,a0
+		addi.w	#10,a0
 		bra.s	.loop_find_left
 ; ===========================================================================
 
@@ -200,7 +200,7 @@ OPL_SpawnObj:
 		bpl.s	OPL_MakeItem				; if not, branch
 		bset	#7,2(a2,d2.w)				; set flag so it isn't loaded more than once
 		beq.s	OPL_MakeItem				; branch if object hasn't already been destroyed
-		add.w	#10,a0					; goto next object in objpos list
+		addi.w	#10,a0					; goto next object in objpos list
 		moveq	#0,d0
 		rts	
 ; ===========================================================================

--- a/Includes/PalLoad & PalPointers.asm
+++ b/Includes/PalLoad & PalPointers.asm
@@ -64,13 +64,13 @@ WaterFilter:
 		move.b	(v_waterfilter_id).w,d0			; get filter id
 		add.w	d0,d0					; multiply by 2
 		move.w	Filter_Index(pc,d0.w),d0
-		
+
 		moveq	#0,d3
 		move.w	#(countof_color*countof_pal)-1,d1
 		lea	(v_pal_dry).w,a0
 		lea	(v_pal_water).w,a1
 		lea	Filter_KeepList(pc),a2
-		
+
 	.loop:
 		move.w	(a0)+,d2				; get colour
 		tst.b	(a2,d3.w)				; check keeplist
@@ -78,10 +78,10 @@ WaterFilter:
 		jsr	Filter_Index(pc,d0.w)
 	.keepcolour:
 		move.w	d2,(a1)+				; write colour
-		add.w	#1,d3					; increment counter
+		addq.w	#1,d3					; increment counter
 		dbf	d1,.loop				; repeat for all colours
 		rts
-		
+
 ; ---------------------------------------------------------------------------
 ; Functions applied to each colour
 
@@ -92,15 +92,15 @@ WaterFilter:
 Filter_Index:	index *
 		ptr Filter_LZ
 		ptr Filter_SBZ3
-		
+
 Filter_LZ:
-		and.w	#$CE2,d2				; remove most red & some blue
+		andi.w	#$CE2,d2				; remove most red & some blue
 		rts
-		
+
 Filter_SBZ3:
-		and.w	#$E0E,d2				; remove green
+		andi.w	#$E0E,d2				; remove green
 		rts
-		
+
 ; ---------------------------------------------------------------------------
 ; Array listing which colours are filtered and which are kept
 ; ---------------------------------------------------------------------------
@@ -111,4 +111,4 @@ Filter_KeepList:
 		dc.b 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
 		dc.b 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
 		even
-		
+

--- a/Includes/PaletteCycle.asm
+++ b/Includes/PaletteCycle.asm
@@ -38,7 +38,7 @@ PCycle_Run:
 		lea	(v_palcycle_buffer).w,a1
 
 	.loop:
-		sub.w	#1,(a1)					; decrement timer
+		subq.w	#1,(a1)					; decrement timer
 		bpl.s	.next					; branch if time remains
 
 		move.w	(a0),(a1)				; reset timer
@@ -54,30 +54,30 @@ PCycle_Run:
 		move.w	2(a0),d1				; get frame count
 		cmp.w	2(a1),d1				; compare current frame with max
 		bne.s	.not_at_max				; branch if not at max
-		move.w	#0,2(a1)				; reset frame counter
+		clr.w	2(a1)				; reset frame counter
 	.not_at_max:
 		tst.w	2(a1)					; check if -1
 		bpl.s	.valid_frame				; branch if not
 		move.w	d1,2(a1)
-		sub.w	#1,2(a1)				; jump to final frame if reversed
+		subq.w	#1,2(a1)				; jump to final frame if reversed
 	.valid_frame:
 		moveq	#0,d1
 		move.b	4(a0),d1				; get colour count
 		move.w	d1,d2
 		add.w	d2,d2
 		mulu.w	2(a1),d2				; d2 = position within source
-		sub.w	#1,d1					; subtract 1 for loops
+		subq.w	#1,d1					; subtract 1 for loops
 		movea.l	6(a0),a2				; get palette data source address
 		movea.l	10(a0),a3				; get palette destination RAM address
 
 	.loop_colour:
 		move.w	(a2,d2.w),(a3)+				; copy 1 colour
-		add.w	#2,d2
+		addq.w	#2,d2
 		dbf	d1,.loop_colour				; repeat for number of colours
 
 	.next:
 		lea	14(a0),a0				; next script
-		lea	4(a1),a1				; next timer/frame counter
+		addq.w	#4,a1				; next timer/frame counter
 		dbf	d0,.loop				; repeat for all scripts
 		rts
 
@@ -153,7 +153,7 @@ PCycle_SBZ3_Script:
 ; ---------------------------------------------------------------------------
 
 PCycle_MZ:
-		rts	
+		rts
 
 ; ---------------------------------------------------------------------------
 ; Star Light Zone
@@ -236,56 +236,56 @@ PCycle_SBZ_Script:
 		dc.b 0
 		dc.l Pal_SBZCyc1
 		dc.l v_pal_dry_line3+(8*2)
-		
+
 		dc.w $D
 		dc.w 8
 		dc.b 1
 		dc.b 0
 		dc.l Pal_SBZCyc2
 		dc.l v_pal_dry_line3+(9*2)
-		
+
 		dc.w $E
 		dc.w 8
 		dc.b 1
 		dc.b 0
 		dc.l Pal_SBZCyc3
 		dc.l v_pal_dry_line4+(7*2)
-		
+
 		dc.w $B
 		dc.w 8
 		dc.b 1
 		dc.b 0
 		dc.l Pal_SBZCyc5
 		dc.l v_pal_dry_line4+(8*2)
-		
+
 		dc.w 7
 		dc.w 8
 		dc.b 1
 		dc.b 0
 		dc.l Pal_SBZCyc6
 		dc.l v_pal_dry_line4+(9*2)
-		
+
 		dc.w $1C
 		dc.w $10
 		dc.b 1
 		dc.b 0
 		dc.l Pal_SBZCyc7
 		dc.l v_pal_dry_line4+(15*2)
-		
+
 		dc.w 3
 		dc.w 3
 		dc.b 1
 		dc.b 0
 		dc.l Pal_SBZCyc8
 		dc.l v_pal_dry_line4+(12*2)
-		
+
 		dc.w 3
 		dc.w 3
 		dc.b 1
 		dc.b 0
 		dc.l Pal_SBZCyc8+2
 		dc.l v_pal_dry_line4+(13*2)
-		
+
 		dc.w 3
 		dc.w 3
 		dc.b 1
@@ -313,42 +313,42 @@ PCycle_SBZ2_Script:
 		dc.b 0
 		dc.l Pal_SBZCyc1
 		dc.l v_pal_dry_line3+(8*2)
-		
+
 		dc.w $D
 		dc.w 8
 		dc.b 1
 		dc.b 0
 		dc.l Pal_SBZCyc2
 		dc.l v_pal_dry_line3+(9*2)
-		
+
 		dc.w 9
 		dc.w 8
 		dc.b 1
 		dc.b 0
 		dc.l Pal_SBZCyc9
 		dc.l v_pal_dry_line4+(8*2)
-		
+
 		dc.w 7
 		dc.w 8
 		dc.b 1
 		dc.b 0
 		dc.l Pal_SBZCyc6
 		dc.l v_pal_dry_line4+(9*2)
-		
+
 		dc.w 3
 		dc.w 3
 		dc.b 1
 		dc.b 0
 		dc.l Pal_SBZCyc8
 		dc.l v_pal_dry_line4+(12*2)
-		
+
 		dc.w 3
 		dc.w 3
 		dc.b 1
 		dc.b 0
 		dc.l Pal_SBZCyc8+2
 		dc.l v_pal_dry_line4+(13*2)
-		
+
 		dc.w 3
 		dc.w 3
 		dc.b 1

--- a/Macros - Objects.asm
+++ b/Macros - Objects.asm
@@ -11,7 +11,7 @@ shortcut:	macro
 	.shortcut_here\@:
 		endc
 		endm
-		
+
 ; ---------------------------------------------------------------------------
 ; Save the parent OST address to ost_parent in a child object
 
@@ -22,9 +22,8 @@ shortcut:	macro
 ;		saveparent					; use after creating a new object
 ; ---------------------------------------------------------------------------
 
-saveparent:	macro
+saveparent:	macros
 		move.w	a0,ost_parent(a1)
-		endm
 
 ; ---------------------------------------------------------------------------
 ; Set a1 as the parent object
@@ -38,7 +37,7 @@ getparent:	macro
 		endc
 		movea.w	ost_parent(a0),\rg
 		endm
-		
+
 ; ---------------------------------------------------------------------------
 ; Set a1 as linked object
 ; ---------------------------------------------------------------------------
@@ -51,7 +50,7 @@ getlinked:	macro
 		endc
 		movea.w	ost_linked(a0),\rg
 		endm
-		
+
 ; ---------------------------------------------------------------------------
 ; Set a1 as Sonic
 ; ---------------------------------------------------------------------------
@@ -63,7 +62,7 @@ getsonic:	macro
 		lea	(v_ost_player).w,a1			; set a1 as Sonic
 		endc
 		endm
-		
+
 ; ---------------------------------------------------------------------------
 ; Set a2 as subsprite table
 ; ---------------------------------------------------------------------------
@@ -76,7 +75,7 @@ getsubsprite:	macro
 		endc
 		movea.w	ost_subsprite(a0),\rg
 		endm
-		
+
 ; ---------------------------------------------------------------------------
 ; Convert speed to position (speed of $100 will move an object 1px per frame)
 
@@ -101,7 +100,7 @@ update_xy_pos:	macro
 		update_x_pos
 		update_y_pos
 		endm
-		
+
 ; ---------------------------------------------------------------------------
 ; Convert speed to position and apply gravity
 
@@ -119,7 +118,7 @@ update_y_fall:	macro
 		addi.w	#$38,ost_y_vel(a0)			; increase falling speed
 		endc
 		endm
-		
+
 update_xy_fall:	macro
 		update_x_pos
 		update_y_pos
@@ -129,7 +128,7 @@ update_xy_fall:	macro
 		addi.w	#$38,ost_y_vel(a0)			; increase falling speed
 		endc
 		endm
-		
+
 ; ---------------------------------------------------------------------------
 ; Get distance between two objects (a0 and a1)
 
@@ -144,7 +143,7 @@ range_x_quick:	macro
 		move.w	ost_x_pos(a1),d0
 		sub.w	ost_x_pos(a0),d0			; d0 = x dist (-ve if Sonic is to the left)
 		endm
-		
+
 range_y_quick:	macro
 		move.w	ost_y_pos(a1),d2
 		sub.w	ost_y_pos(a0),d2			; d2 = y dist (-ve if Sonic is above)
@@ -154,7 +153,7 @@ range_x:	macro
 		range_x_quick					; d0 = x dist (-ve if Sonic is to the left)
 		mvabs.w	d0,d1					; make d1 +ve
 		endm
-		
+
 range_y:	macro
 		range_y_quick					; d2 = y dist (-ve if Sonic is above)
 		mvabs.w	d2,d3					; make d3 +ve
@@ -215,7 +214,7 @@ range_x_exact:	macro
 		move.b	ost_width(a0),d4
 		sub.w	d4,d1					; d1 = x dist between hitbox edges (-ve if overlapping)
 		endm
-		
+
 range_x_sonic:	macro
 		range_x
 		moveq	#0,d4
@@ -226,7 +225,7 @@ range_x_sonic:	macro
 		sub.w	d4,d1					; d1 = x dist between hitbox edges (-ve if overlapping)
 		add.w	d0,d4					; d4 = Sonic's x pos relative to left edge
 		endm
-		
+
 range_x_sonic0:	macro						; as above, but ignoring Sonic's width
 		range_x
 		moveq	#0,d4
@@ -234,7 +233,7 @@ range_x_sonic0:	macro						; as above, but ignoring Sonic's width
 		sub.w	d4,d1					; d1 = x dist between Sonic's x pos and object hitbox edge (-ve if overlapping)
 		add.w	d0,d4					; d4 = Sonic's x pos relative to left edge
 		endm
-		
+
 range_y_exact:	macro
 		range_y
 		moveq	#0,d5
@@ -244,7 +243,7 @@ range_y_exact:	macro
 		addq.b	#1,d5
 		sub.w	d5,d3					; d3 = y dist between hitbox edges (-ve if overlapping)
 		endm
-		
+
 ; ---------------------------------------------------------------------------
 ; Set the animation id of an object to d0 (do nothing if it's the same as d0)
 
@@ -311,7 +310,7 @@ toggleframe:	macro
 		bchg	#0,ost_frame(a0)			; toggle between frame 0 and 1
 		endc
 		endm
-		
+
 ; ---------------------------------------------------------------------------
 ; Multiply a number by 60
 
@@ -328,4 +327,4 @@ mul60:		macro
 		add.w	\2,\2
 		sub.w	\2,\1
 		endm
-		
+

--- a/Macros.asm
+++ b/Macros.asm
@@ -141,7 +141,7 @@ index:		macro
 		else
 		index_width: equs "\0"
 		endc
-		
+
 		if strcmp("\index_width","b")
 		index_width_int: = 1
 		elseif strcmp("\index_width","w")
@@ -151,7 +151,7 @@ index:		macro
 		else
 		fail
 		endc
-		
+
 		if strlen("\2")=0				; check if first pointer id is defined
 		ptr_id: = 0					; use 0 by default
 		else
@@ -162,13 +162,13 @@ index:		macro
 		else
 		ptr_id_inc: = \3
 		endc
-		
+
 		tmp_array: equs "empty"				; clear tmp_array
 
 		popo
 		list
 		endm
-	
+
 ; ---------------------------------------------------------------------------
 ; Create a mirrored pointer index. Used to keep Sonic's mappings & DPLC
 ; indexes aligned.
@@ -212,11 +212,11 @@ ptr:		macro
 		else
 		dc.\index_width \1-index_start
 		endc
-		
+
 		if ~def(prefix_id)
 		prefix_id: equs "id_"
 		endc
-		
+
 		if instr("\1",".")=1				; check if pointer is local
 		else
 			if ~def(\prefix_id\\1)
@@ -225,7 +225,7 @@ ptr:		macro
 			\prefix_id\\1_\$ptr_id: equ ptr_id	; if id already exists, append number
 			endc
 		endc
-		
+
 		if strlen("\2")=0				; check if label should be stored
 		else
 			if strcmp("\tmp_array","empty")
@@ -235,7 +235,7 @@ ptr:		macro
 			endc
 		\2: equs tmp_array
 		endc
-		
+
 		ptr_id: = ptr_id+ptr_id_inc			; increment id
 
 		popo
@@ -264,7 +264,7 @@ locVRAM:	macro loc,controlport
 dma:		macro source,length,dest1,dest2
 		dma_type: = $4000
 		dma_type2: = $80
-		
+
 		if strcmp("\dest1","cram")
 		dma_type: = $C000
 			ifarg \dest2
@@ -282,7 +282,7 @@ dma:		macro source,length,dest1,dest2
 		else
 		dma_dest: = \dest1
 		endc
-		
+
 		lea	(vdp_control_port).l,a6
 		move.l	#$94000000+(((\length>>1)&$FF00)<<8)+$9300+((\length>>1)&$FF),(a6)
 		move.l	#$96000000+(((\source>>1)&$FF00)<<8)+$9500+((\source>>1)&$FF),(a6)
@@ -396,7 +396,7 @@ piece:		macro
 		else
 			sprite_tile: = \4
 		endc
-		
+
 		sprite_xflip: = 0
 		sprite_yflip: = 0
 		sprite_hi: = 0
@@ -418,7 +418,7 @@ piece:		macro
 			endc
 		shift
 		endr
-		
+
 		dc.w (sprite_tile+sprite_xflip+sprite_yflip+sprite_hi+sprite_pal)&$FFFF
 		dc.w sprite_xpos
 		endm
@@ -453,7 +453,7 @@ objpos:		macro xpos,ypos,id,subtype
 		shift
 		endr
 		endc
-		
+
 		dc.b obj_rem+obj_xflip+obj_yflip, obj_sub\@
 		dc.l obj_id
 		endm
@@ -595,16 +595,15 @@ evenr:		macro
 		exg	d0,\1
 		btst	#0,d0
 		beq.s	.already_even\@				; branch if already even
-		add.l	#1,d0					; skip odd byte
+		addq.l	#1,d0					; skip odd byte
 	.already_even\@:
 		exg	d0,\1
 		endm
-		
+
 ; ---------------------------------------------------------------------------
 ; Don't return to previous code from subroutine
 ; ---------------------------------------------------------------------------
 
-noreturn:	macro
-		addq.l	#4,sp					; skip last location in stack
-		endm
-		
+noreturn:	macros
+		addq.w	#4,sp					; skip last location in stack
+

--- a/Objects/Ball Hog Cannonball.asm
+++ b/Objects/Ball Hog Cannonball.asm
@@ -26,7 +26,7 @@ Cbal_Main:	; Routine 0
 		move.b	#7,ost_height(a0)
 		move.l	#Map_Hog,ost_mappings(a0)
 		move.w	(v_tile_ballhog).w,ost_tile(a0)
-		add.w	#tile_pal2,ost_tile(a0)
+		addi.w	#tile_pal2,ost_tile(a0)
 		move.b	#render_rel,ost_render(a0)
 		move.b	#priority_3,ost_priority(a0)
 		move.b	#id_React_Hurt,ost_col_type(a0)

--- a/Objects/Ball Hog.asm
+++ b/Objects/Ball Hog.asm
@@ -26,7 +26,7 @@ Hog_Main:	; Routine 0
 		move.b	#8,ost_width(a0)
 		move.l	#Map_Hog,ost_mappings(a0)
 		move.w	(v_tile_ballhog).w,ost_tile(a0)
-		add.w	#tile_pal2,ost_tile(a0)
+		addi.w	#tile_pal2,ost_tile(a0)
 		move.b	#render_rel,ost_render(a0)
 		move.b	#priority_4,ost_priority(a0)
 		move.b	#id_React_Enemy,ost_col_type(a0)

--- a/Objects/Batbrain.asm
+++ b/Objects/Batbrain.asm
@@ -23,7 +23,7 @@ Bat_Main:	; Routine 0
 		addq.b	#2,ost_routine(a0)			; goto Bat_Hang next
 		move.l	#Map_Bat,ost_mappings(a0)
 		move.w	(v_tile_batbrain).w,ost_tile(a0)
-		add.w	#tile_hi,ost_tile(a0)
+		addi.w	#tile_hi,ost_tile(a0)
 		move.b	#render_rel,ost_render(a0)
 		move.b	#$C,ost_height(a0)
 		move.b	#priority_2,ost_priority(a0)
@@ -36,7 +36,7 @@ Bat_Hang:	; Routine 2
 		getsonic					; a1 = OST of Sonic
 		range_y_quick
 		bmi.w	DespawnObject				; branch if Sonic is above
-		cmp.w	#128,d2
+		cmpi.w	#128,d2
 		bge.w	DespawnObject				; branch if > 128px below
 		range_x_test	128
 		bcc.w	DespawnObject				; branch if > 128px away
@@ -57,7 +57,7 @@ Bat_Drop:	; Routine 4
 		getsonic					; a1 = OST of Sonic
 		range_y_quick
 		bmi.s	.chkdel					; branch if Sonic is above
-		cmp.w	#16,d2
+		cmpi.w	#16,d2
 		bcc.w	DespawnObject				; branch if > 16px below
 		move.w	#$100,d1				; batbrain will fly right
 		btst	#status_xflip_bit,ost_status(a0)

--- a/Objects/Boss Face.asm
+++ b/Objects/Boss Face.asm
@@ -72,7 +72,7 @@ Face_Chk:	; Routine 2
 		beq.s	.exit					; branch if no defeat routine is specified
 		cmp.b	ost_mode(a3),d0
 		bls.s	Face_Goto_Defeat			; branch if boss is on specified routine
-		cmp.b	#2,ost_subtype(a3)
+		cmpi.b	#2,ost_subtype(a3)
 		beq.s	Face_Goto_Lift				; branch if boss is lifting a block (SYZ only)
 
 	.exit:
@@ -140,7 +140,7 @@ Face_Panic:	; Routine
 Face_Lift:	; Routine
 		tst.b	ost_boss_flash_num(a3)
 		bne.w	Face_Goto_Hit				; branch if boss is flashing
-		cmp.b	#2,ost_subtype(a3)
+		cmpi.b	#2,ost_subtype(a3)
 		bne.w	Face_Goto_Default			; branch if boss isn't lifting a block
 		rts
 

--- a/Objects/Boss Weapons.asm
+++ b/Objects/Boss Weapons.asm
@@ -76,9 +76,9 @@ Weapon_Spike:	; Routine 4
 		bne.s	.exit					; branch if boss isn't attacking
 		cmpi.b	#id_BSYZ_BreakBlock,ost_subtype(a3)
 		beq.s	.retract				; branch if boss is breaking block
-		cmp.w	#$94,ost_weapon_y_diff(a0)
+		cmpi.w	#$94,ost_weapon_y_diff(a0)
 		bge.s	.exit					; branch if spike is fully extended
-		add.w	#7,ost_weapon_y_diff(a0)
+		addq.w	#7,ost_weapon_y_diff(a0)
 		move.b	#id_React_Hurt,ost_col_type(a0)		; make spike harmful
 		move.b	#4,ost_col_width(a0)
 		move.b	#16,ost_col_height(a0)
@@ -91,7 +91,7 @@ Weapon_Spike:	; Routine 4
 		bpl.s	.exit					; branch if boss is shaking
 		tst.w	ost_weapon_y_diff(a0)
 		bmi.s	.gone					; branch if spike is fully retracted
-		sub.w	#5,ost_weapon_y_diff(a0)
+		subq.w	#5,ost_weapon_y_diff(a0)
 		rts
 		
 	.gone:

--- a/Objects/Burrobot.asm
+++ b/Objects/Burrobot.asm
@@ -46,7 +46,7 @@ Burro_ChkSonic:	; Routine $A
 		bcc.w	DespawnObject				; branch if Sonic is > $60px away
 		range_y_quick
 		bpl.w	DespawnObject				; branch if Sonic is below
-		cmp.w	#-$80,d2
+		cmpi.w	#-$80,d2
 		blt.w	DespawnObject				; branch if Sonic is > $80px above
 		tst.w	(v_debug_active).w
 		bne.w	DespawnObject				; branch if debug mode is on

--- a/Objects/Button.asm
+++ b/Objects/Button.asm
@@ -43,7 +43,7 @@ But_Main:	; Routine 0
 		btst	#type_button_pal3_bit,ost_subtype(a0)	; is subtype +$10?
 		beq.s	.not_marble				; if not, branch
 
-		add.w	#tile_pal3,ost_tile(a0)			; use different palette line
+		addi.w	#tile_pal3,ost_tile(a0)			; use different palette line
 
 	.not_marble:
 		move.b	#render_rel,ost_render(a0)

--- a/Objects/Buzz Bomber Missile.asm
+++ b/Objects/Buzz Bomber Missile.asm
@@ -35,7 +35,7 @@ Msl_Main:	; Routine 0
 		bpl.s	.verify					; branch if time remains
 		move.l	#Map_Missile,ost_mappings(a0)
 		move.w	(v_tile_buzzbomber).w,ost_tile(a0)
-		add.w	#tile_pal2,ost_tile(a0)
+		addi.w	#tile_pal2,ost_tile(a0)
 		move.b	#render_rel+render_onscreen,ost_render(a0)
 		move.b	#priority_3,ost_priority(a0)
 		move.b	#8,ost_displaywidth(a0)

--- a/Objects/Caterkiller.asm
+++ b/Objects/Caterkiller.asm
@@ -44,7 +44,7 @@ Cat_Main:	; Routine 0
 		addq.b	#2,ost_routine(a0)			; goto Cat_Head next
 		move.l	#Map_Cat,ost_mappings(a0)
 		move.w	(v_tile_caterkiller).w,ost_tile(a0)
-		add.w	#tile_pal2,ost_tile(a0)
+		addi.w	#tile_pal2,ost_tile(a0)
 		move.b	ost_status(a0),ost_render(a0)
 		ori.b	#render_rel,ost_render(a0)
 		move.b	#priority_4,ost_priority(a0)

--- a/Objects/Continue Screen Items.asm
+++ b/Objects/Continue Screen Items.asm
@@ -66,13 +66,13 @@ CSI_MakeMiniSonic:
 		mulu.w	#minisonic_spacing/2,d3
 		add.w	d3,d2
 		neg.w	d2
-		add.w	#screen_left+(screen_width/2),d2	; d2 = x pos of leftmost mini Sonic
+		addi.w	#screen_left+(screen_width/2),d2	; d2 = x pos of leftmost mini Sonic
 	
 	.loop:
 		jsr	FindFreeInert
 		move.l	#ContScrItem,ost_id(a1)			; load mini Sonic object
 		move.w	d2,ost_x_pos(a1)
-		add.w	#minisonic_width+minisonic_spacing,d2	; x pos for next mini Sonic
+		addi.w	#minisonic_width+minisonic_spacing,d2	; x pos for next mini Sonic
 		move.w	#screen_top+80,ost_y_screen(a1)
 		move.b	#id_frame_cont_mini1,ost_frame(a1)
 		move.b	#id_CSI_AniMiniSonic,ost_routine(a1)
@@ -118,7 +118,7 @@ CSI_Counter:	; Routine 8
 		move.w	(v_countdown).w,d0			; get counter
 		divu.w	#60,d0					; convert to seconds
 		andi.w	#$F,d0					; read only lowest nybble
-		add.w	#id_frame_cont_0,d0			; start from 0
+		addq.w	#id_frame_cont_0,d0			; start from 0
 		move.b	d0,ost_frame(a0)			; update frame
 		
 	.sonic_running:

--- a/Objects/Ending Chaos Emeralds Try Again.asm
+++ b/Objects/Ending Chaos Emeralds Try Again.asm
@@ -102,7 +102,7 @@ TCha_Arc:	; Routine 6
 		bsr.s	TCha_Update				; update position
 		move.b	ost_angle(a0),d0
 		beq.s	.stopmoving
-		cmp.b	#$80,d0
+		cmpi.b	#$80,d0
 		bne.s	.keepmoving				; branch if emerald has been caught
 		
 	.stopmoving:

--- a/Objects/GHZ & SLZ Smashable Walls.asm
+++ b/Objects/GHZ & SLZ Smashable Walls.asm
@@ -21,7 +21,7 @@ Smash_Main:	; Routine 0
 		addq.b	#2,ost_routine(a0)			; goto Smash_Solid next
 		move.l	#Map_Smash,ost_mappings(a0)
 		move.w	(v_tile_wall).w,ost_tile(a0)
-		add.w	#tile_pal3,ost_tile(a0)
+		addi.w	#tile_pal3,ost_tile(a0)
 		move.b	#render_rel,ost_render(a0)
 		move.b	#$10,ost_displaywidth(a0)
 		move.b	#priority_4,ost_priority(a0)

--- a/Objects/HUD.asm
+++ b/Objects/HUD.asm
@@ -220,11 +220,11 @@ HUD_TimeCount:	; Routine $A
 		cmpi.b	#60,d0
 		bne.s	.update_time				; branch if frame counter is below 60
 		move.b	#0,d0					; reset frame counter
-		add.w	#$100,d0				; increment seconds counter
+		addi.w	#$100,d0				; increment seconds counter
 		cmpi.w	#60<<8,d0
 		bne.s	.update_time				; branch if seconds counter is below 60
 		move.w	#0,d0					; reset seconds counter
-		add.l	#$10000,d0				; increment minutes counter
+		addi.l	#$10000,d0				; increment minutes counter
 		cmpi.l	#10<<16,d0
 		beq.w	HUD_TimeOver				; branch if counter hits 10 minutes
 		
@@ -284,18 +284,18 @@ HUD_ShowLong:
 		moveq	#-1,d2
 	.loop_digit6:
 		addq.b	#1,d2					; increment digit counter
-		sub.l	#100000,d0				; decrement highest digit
+		subi.l	#100000,d0				; decrement highest digit
 		bcc.s	.loop_digit6				; branch if +ve
-		add.l	#100000,d0				; restore to +ve
+		addi.l	#100000,d0				; restore to +ve
 		move.b	d2,-2(a4)				; set highest digit
 		
 	.skip_digit6:
 		moveq	#-1,d2
 	.loop_digit5:
 		addq.b	#1,d2					; increment digit counter
-		sub.l	#10000,d0				; decrement 5th digit
+		subi.l	#10000,d0				; decrement 5th digit
 		bcc.s	.loop_digit5				; branch if +ve
-		add.l	#10000,d0				; restore to +ve
+		addi.l	#10000,d0				; restore to +ve
 		move.b	d2,-1(a4)				; set 5th digit
 		
 	.skip_digit5:
@@ -315,7 +315,7 @@ HUD_ShowLong:
 		move.b	-(a4),d0				; get digit
 	.hide_digit:
 		bsr.w	HUD_ShowDigit				; load digit gfx
-		sub.l	#$400000,d1				; go back 2 tiles in VRAM
+		subi.l	#$400000,d1				; go back 2 tiles in VRAM
 		dbf	d4,.loop				; repeat for all digits
 		
 	.exit:
@@ -384,14 +384,14 @@ HUD_ShowByte:
 		lea	HUD_ByteGfxIndex(pc,d3.w),a2
 		set_dma_size	sizeof_cell,d2			; set size to 1 cell
 		jsr	(AddDMA).w				; load high digit
-		add.l	#$200000,d1				; next tile in VRAM
+		addi.l	#$200000,d1				; next tile in VRAM
 		
 		move.b	d0,d3
 		andi.b	#$F,d3					; read low nybble of byte
 		lsl.b	#3,d3					; multiply by 8
 		lea	HUD_ByteGfxIndex(pc,d3.w),a2
 		jsr	(AddDMA).w				; load low digit
-		add.l	#$200000,d1				; next tile in VRAM
+		addi.l	#$200000,d1				; next tile in VRAM
 		rts
 		
 HUD_ByteGfxIndex:

--- a/Objects/Jaws.asm
+++ b/Objects/Jaws.asm
@@ -25,7 +25,7 @@ Jaws_Main:	; Routine 0
 		addq.b	#2,ost_routine(a0)			; goto Jaws_Turn next
 		move.l	#Map_Jaws,ost_mappings(a0)
 		move.w	(v_tile_jaws).w,ost_tile(a0)
-		add.w	#tile_pal2,ost_tile(a0)
+		addi.w	#tile_pal2,ost_tile(a0)
 		ori.b	#render_rel,ost_render(a0)
 		move.b	#id_React_Enemy,ost_col_type(a0)
 		move.b	#16,ost_col_width(a0)

--- a/Objects/LZ Bubbles.asm
+++ b/Objects/LZ Bubbles.asm
@@ -101,7 +101,7 @@ Bub_Big2:	; Routine 8
 		bcc.w	DespawnQuick
 		range_y_quick
 		bmi.w	DespawnQuick				; branch if Sonic is above bubble
-		cmp.w	#16,d2
+		cmpi.w	#16,d2
 		bcc.w	DespawnQuick
 
 		bsr.w	ResumeMusic				; cancel countdown music & reset air

--- a/Objects/LZ Door Horizontal.asm
+++ b/Objects/LZ Door Horizontal.asm
@@ -37,7 +37,7 @@ DoorH_Main:	; Routine 0
 
 		btst	#status_xflip_bit,ost_status(a0)
 		beq.s	.no_xflip				; branch if not xflipped
-		add.w	#128,ost_x_pos(a0)			; move into open position
+		addi.w	#128,ost_x_pos(a0)			; move into open position
 		move.w	#-128,d1
 
 	.no_xflip:

--- a/Objects/LZ Door Vertical.asm
+++ b/Objects/LZ Door Vertical.asm
@@ -39,7 +39,7 @@ DoorV_Main:	; Routine 0
 		bsr.w	GetState
 		bne.s	DoorV_Solid				; branch if already opened
 		move.w	ost_y_pos(a0),ost_doorv_y_start(a0)	; copy open position
-		add.w	#64,ost_y_pos(a0)			; move into closed position
+		addi.w	#64,ost_y_pos(a0)			; move into closed position
 		addq.b	#2,ost_routine(a0)			; goto DoorV_ChkBtn next
 
 DoorV_Solid:	; Routine 2

--- a/Objects/Lamppost.asm
+++ b/Objects/Lamppost.asm
@@ -103,7 +103,7 @@ Lamp_Red:	; Routine 4
 Lamp_Twirl:	; Routine 6
 		shortcut
 		move.w	ost_lamp_twirl_count(a0),d0
-		add.w	#4,d0					; increment counter
+		addq.w	#4,d0					; increment counter
 		cmpi.w	#32*4,d0
 		bne.s	.keep_twirling				; keep twirling until finished
 		getparent					; a1 = OST of actual lamppost

--- a/Objects/Monitors.asm
+++ b/Objects/Monitors.asm
@@ -55,7 +55,7 @@ Mon_Main:	; Routine 0
 ; ===========================================================================
 
 	.not_broken:
-		cmp.b	#type_monitor_1up,ost_subtype(a0)
+		cmpi.b	#type_monitor_1up,ost_subtype(a0)
 		bne.s	.not_1up				; branch if monitor isn't a 1-up
 		move.b	#id_ani_monitor_sonic,ost_anim(a0)	; use 1-up animation
 		bra.s	Mon_Solid				; skip slot check
@@ -99,7 +99,7 @@ Mon_Break:	; Routine 4
 		move.b	ost_subtype(a0),ost_subtype(a1)		; inherit subtype
 		move.b	ost_monitor_slot(a0),ost_pow_slot(a1)
 		move.b	#id_frame_monitor_static1,ost_frame(a1)	; use static icon by default
-		cmp.b	#type_monitor_1up,ost_subtype(a0)
+		cmpi.b	#type_monitor_1up,ost_subtype(a0)
 		bne.s	.not_1up				; branch if not 1-up
 		move.b	#id_frame_monitor_sonic,ost_frame(a1)	; use 1-up icon instead
 
@@ -172,7 +172,7 @@ Mon_Solid_Detect:
 		bne.w	Sol_Stand				; branch if Sonic is already standing on object
 		getsonic
 		range_x_sonic					; get distances between Sonic (a1) and object (a0)
-		cmp.w	#0,d1
+		tst.w	d1
 		bgt.w	Sol_None				; branch if outside x hitbox
 		range_y_exact
 		bpl.w	Sol_None				; branch if outside y hitbox

--- a/Objects/Newtron.asm
+++ b/Objects/Newtron.asm
@@ -46,7 +46,7 @@ Newt_Main:	; Routine 0
 		move.b	ost_subtype(a0),d0
 		btst	#type_newt_pal2_bit,d0
 		beq.s	.keep_pal
-		add.w	#tile_pal2,ost_tile(a0)
+		addi.w	#tile_pal2,ost_tile(a0)
 		
 	.keep_pal:
 		move.b	#render_rel,ost_render(a0)

--- a/Objects/Orbinaut.asm
+++ b/Objects/Orbinaut.asm
@@ -49,7 +49,7 @@ Orb_Main:	; Routine 0
 		move.b	ost_subtype(a0),d4
 		btst	#type_orbinaut_pal2_bit,d4		; check if low bit of subtype is set
 		beq.s	.use_pal1				; if not, branch
-		add.w	#tile_pal2,ost_tile(a0)			; use palette 2
+		addi.w	#tile_pal2,ost_tile(a0)			; use palette 2
 
 	.use_pal1:
 		ori.b	#render_rel,ost_render(a0)

--- a/Objects/Points.asm
+++ b/Objects/Points.asm
@@ -20,7 +20,7 @@ Poi_Main:	; Routine 0
 		addq.b	#2,ost_routine(a0)			; goto Poi_Slower next
 		move.l	#Map_Points,ost_mappings(a0)
 		move.w	(v_tile_points).w,ost_tile(a0)
-		add.w	#tile_pal2,ost_tile(a0)
+		addi.w	#tile_pal2,ost_tile(a0)
 		move.b	#render_rel,ost_render(a0)
 		move.b	#priority_1,ost_priority(a0)
 		move.b	#8,ost_displaywidth(a0)

--- a/Objects/Ring Loss.asm
+++ b/Objects/Ring Loss.asm
@@ -56,7 +56,7 @@ RLoss_Count:	; Routine 0
 		move.w	ost_y_pos(a0),ost_y_pos(a1)
 		move.l	#Map_Ring,ost_mappings(a1)
 		move.w	(v_tile_rings).w,ost_tile(a1)
-		add.w	#tile_pal2,ost_tile(a1)
+		addi.w	#tile_pal2,ost_tile(a1)
 		move.b	#render_rel,ost_render(a1)
 		move.b	#priority_3,ost_priority(a1)
 		move.b	#id_React_Ring,ost_col_type(a1)		; goto RLoss_Collect when touched

--- a/Objects/Rings.asm
+++ b/Objects/Rings.asm
@@ -101,7 +101,7 @@ Ring_Main:	; Routine 0
 		move.w	d3,ost_y_pos(a1)			; set y position based on d3
 		move.l	#Map_Ring,ost_mappings(a1)
 		move.w	(v_tile_rings).w,ost_tile(a1)
-		add.w	#tile_pal2,ost_tile(a1)
+		addi.w	#tile_pal2,ost_tile(a1)
 		move.b	#render_rel,ost_render(a1)
 		move.b	#priority_2,ost_priority(a1)
 		move.b	#id_React_Ring,ost_col_type(a1)		; goto Ring_Collect when touched

--- a/Objects/SBZ Door Horizontal.asm
+++ b/Objects/SBZ Door Horizontal.asm
@@ -40,7 +40,7 @@ SDoorH_Main:	; Routine 0
 		
 		btst	#status_xflip_bit,ost_status(a0)
 		beq.s	SDoorH_ChkBtn				; branch if not xflipped
-		sub.w	#128,ost_x_pos(a0)			; starts in left position
+		subi.w	#128,ost_x_pos(a0)			; starts in left position
 
 SDoorH_ChkBtn:	; Routine 2
 		lea	(v_button_state).w,a2

--- a/Objects/Signpost & HasPassedAct.asm
+++ b/Objects/Signpost & HasPassedAct.asm
@@ -86,7 +86,7 @@ Sign_Spin:	; Routine 4
 		move.w	d0,ost_y_pos(a1)
 		move.l	#Map_Ring,ost_mappings(a1)
 		move.w	(v_tile_rings).w,ost_tile(a1)
-		add.w	#tile_pal2,ost_tile(a1)
+		addi.w	#tile_pal2,ost_tile(a1)
 		move.b	#render_rel,ost_render(a1)
 		move.b	#priority_2,ost_priority(a1)
 		move.b	#8,ost_displaywidth(a1)

--- a/Objects/Special Stage Results.asm
+++ b/Objects/Special Stage Results.asm
@@ -81,7 +81,7 @@ SSR_Main:	; Routine 0
 		move.b	#id_Has_WaitEnter,ost_routine(a1)
 		move.l	#Map_Has,ost_mappings(a1)
 		move.w	(v_tile_bonus).w,ost_tile(a1)
-		add.w	#tile_hi,ost_tile(a1)
+		addi.w	#tile_hi,ost_tile(a1)
 		move.b	#render_abs,ost_render(a1)
 		move.b	#priority_0,ost_priority(a1)
 		move.b	d1,ost_frame(a1)
@@ -91,9 +91,9 @@ SSR_Main:	; Routine 0
 		move.w	#screen_right,ost_x_pos(a1)
 		move.w	#screen_left+80,ost_has_x_stop(a1)	; x pos when text stops on screen
 		move.w	d2,ost_y_screen(a1)
-		add.w	#16,d2					; spacing between lines of text
+		addi.w	#16,d2					; spacing between lines of text
 		move.w	d3,ost_has_time(a1)
-		add.w	#2,d3					; 2 frame delay between each line
+		addq.w	#2,d3					; 2 frame delay between each line
 		dbf	d1,.loop
 		
 		cmpi.w	#rings_for_continue,(v_rings).w
@@ -103,7 +103,7 @@ SSR_Main:	; Routine 0
 		move.b	#id_Has_WaitEnter,ost_routine(a1)
 		move.l	#Map_Has,ost_mappings(a1)
 		move.w	(v_tile_bonus).w,ost_tile(a1)
-		add.w	#tile_hi,ost_tile(a1)
+		addi.w	#tile_hi,ost_tile(a1)
 		move.b	#render_abs,ost_render(a1)
 		move.b	#priority_0,ost_priority(a1)
 		move.b	#id_frame_has_continue,ost_frame(a1)
@@ -136,7 +136,7 @@ SSR_WaitBonus:	; Routine 2
 		clr.b	(f_pass_bonus_update).w			; clear ring bonus update flag
 		subq.w	#1,ost_ssr_time(a0)			; decrement timer
 		bpl.s	.wait					; branch if time remains
-		add.b	#2,ost_routine(a0)			; goto SSR_Bonus next
+		addq.b	#2,ost_routine(a0)			; goto SSR_Bonus next
 		
 	.wait:
 		rts
@@ -154,7 +154,7 @@ SSR_Bonus:	; Routine 4
 		tst.w	d0					; is there any bonus?
 		bne.s	.add_bonus				; if yes, branch
 		play.w	1, jsr, sfx_Register			; play "ker-ching" sound
-		add.b	#2,ost_routine(a0)			; goto SSR_Finish next
+		addq.b	#2,ost_routine(a0)			; goto SSR_Finish next
 		move.w	#180,ost_ssr_time(a0)			; set time delay to 3 seconds
 		cmpi.w	#rings_for_continue,(v_rings).w
 		bcs.s	.exit					; branch if you have under 50 rings

--- a/Objects/Splats.asm
+++ b/Objects/Splats.asm
@@ -21,7 +21,7 @@ Splats_Main:	; Routine 0
 		addq.b	#2,ost_routine(a0)			; goto Splats_ChkDist next
 		move.l	#Map_Splats,ost_mappings(a0)
 		move.w	(v_tile_splats).w,ost_tile(a0)
-		add.w	#tile_pal2,ost_tile(a0)
+		addi.w	#tile_pal2,ost_tile(a0)
 		move.b	#render_rel,ost_render(a0)
 		move.b	#priority_4,ost_priority(a0)
 		move.b	#$C,ost_displaywidth(a0)

--- a/Objects/Title Cards Sonic Has Passed.asm
+++ b/Objects/Title Cards Sonic Has Passed.asm
@@ -43,9 +43,9 @@ Has_Main:	; Routine 0
 		add.w	(v_haspassed_uplc).w,d0
 		jsr	UncPLC					; load title card patterns
 		move.w	(v_titlecard_act).w,d0
-		sub.w	#2,d0
+		subq.w	#2,d0
 		bcs.s	.keep_act				; branch if act is 0 or 1
-		add.w	#id_UPLC_Act2Card,d0
+		addi.w	#id_UPLC_Act2Card,d0
 		jsr	UncPLC					; load act 2/3 gfx
 		
 	.keep_act:
@@ -64,16 +64,16 @@ Has_Main:	; Routine 0
 		move.b	#id_Has_WaitEnter,ost_routine(a1)
 		move.l	#Map_Has,ost_mappings(a1)
 		move.w	(v_tile_bonus).w,ost_tile(a1)
-		add.w	#tile_hi,ost_tile(a1)
+		addi.w	#tile_hi,ost_tile(a1)
 		move.b	#render_abs,ost_render(a1)
 		move.b	#priority_0,ost_priority(a1)
 		move.b	d1,ost_frame(a1)			; use frames 2, 1 and 0
 		move.w	#screen_right,ost_x_pos(a1)
 		move.w	#screen_left+80,ost_has_x_stop(a1)	; x pos when text stops on screen
 		move.w	d2,ost_y_screen(a1)
-		add.w	#16,d2					; spacing between lines of text
+		addi.w	#16,d2					; spacing between lines of text
 		move.w	d3,ost_has_time(a1)
-		add.w	#2,d3					; 2 frame delay between each line
+		addq.w	#2,d3					; 2 frame delay between each line
 		dbf	d1,.loop
 		
 		jsr	FindFreeInert
@@ -94,18 +94,18 @@ Has_Main:	; Routine 0
 Has_WaitEnter:	; Routine 2
 		subq.w	#1,ost_has_time(a0)			; decrement timer
 		bpl.s	.wait					; branch if time remains
-		add.b	#2,ost_routine(a0)			; goto Has_Enter next
+		addq.b	#2,ost_routine(a0)			; goto Has_Enter next
 		
 	.wait:
 		rts
 		
 Has_Enter:	; Routine 4
 		move.w	ost_x_pos(a0),d0
-		sub.w	#16,d0					; move 16px left
+		subi.w	#16,d0					; move 16px left
 		move.w	ost_has_x_stop(a0),d1
 		cmp.w	d0,d1
 		bcs.s	.not_at_stop				; branch if not at target x pos
-		add.b	#2,ost_routine(a0)			; goto Has_Display next
+		addq.b	#2,ost_routine(a0)			; goto Has_Display next
 		move.w	d1,d0					; snap to target
 		
 	.not_at_stop:
@@ -148,7 +148,7 @@ Has_WaitBonus:	; Routine $C
 		clr.b	(f_pass_bonus_update).w			; clear time/ring bonus update flag
 		subq.w	#1,ost_has_time(a0)			; decrement timer
 		bpl.s	.wait					; branch if time remains
-		add.b	#2,ost_routine(a0)			; goto Has_Bonus next
+		addq.b	#2,ost_routine(a0)			; goto Has_Bonus next
 		
 	.wait:
 		rts
@@ -172,7 +172,7 @@ Has_Bonus:	; Routine $E
 		tst.w	d0					; is there any bonus?
 		bne.s	.add_bonus				; if yes, branch
 		play.w	1, jsr, sfx_Register			; play "ker-ching" sound
-		add.b	#2,ost_routine(a0)			; goto Has_Finish next
+		addq.b	#2,ost_routine(a0)			; goto Has_Finish next
 		move.w	#180,ost_has_time(a0)			; set time delay to 3 seconds
 		rts
 		

--- a/Objects/Title Cards.asm
+++ b/Objects/Title Cards.asm
@@ -163,9 +163,9 @@ Card_Main:	; Routine 0
 		move.w	(v_titlecard_uplc).w,d0
 		jsr	UncPLC					; load title card gfx
 		move.w	(v_titlecard_act).w,d0
-		sub.w	#2,d0
+		subq.w	#2,d0
 		bcs.s	.keep_act				; branch if act is 0 or 1
-		add.w	#id_UPLC_Act2Card,d0
+		addi.w	#id_UPLC_Act2Card,d0
 		jsr	UncPLC					; load act 2/3 gfx
 		
 	.keep_act:
@@ -195,7 +195,7 @@ Card_Load:
 		move.l	(a2)+,ost_card_x_speed2(a1)		; set x/y speed for leaving screen
 		movea.l	(a2)+,a3
 		move.w	(a3),ost_tile(a1)
-		add.w	#tile_hi,ost_tile(a1)
+		addi.w	#tile_hi,ost_tile(a1)
 		move.w	(a2)+,d0
 		move.b	d0,ost_displaywidth(a1)
 		move.b	#render_abs,ost_render(a1)
@@ -213,7 +213,7 @@ Card_WaitEnter:	; Routine 2
 	.flag_set:
 		subq.w	#1,ost_card_time(a0)			; decrement timer
 		bpl.s	.wait					; branch if time remains
-		add.b	#2,ost_routine(a0)			; goto Card_Enter next
+		addq.b	#2,ost_routine(a0)			; goto Card_Enter next
 		
 	.wait:
 		rts
@@ -251,7 +251,7 @@ Card_Enter:	; Routine 4
 		bne.s	.not_at_stop				; branch if not at stop x/y pos
 		move.w	ost_card_x_stop(a0),ost_x_pos(a0)
 		move.w	ost_card_y_stop(a0),ost_y_screen(a0)	; force precise x/y pos
-		add.b	#2,ost_routine(a0)			; goto Card_WaitLeave next
+		addq.b	#2,ost_routine(a0)			; goto Card_WaitLeave next
 		addq.b	#1,(v_titlecard_state).w
 		
 	.not_at_stop:
@@ -265,7 +265,7 @@ Card_WaitLeave:	; Routine 6
 		bne.s	.wait					; branch if on "Sonic Has Passed" card
 		subq.w	#1,ost_card_time2(a0)			; decrement timer
 		bpl.s	.wait					; branch if time remains
-		add.b	#2,ost_routine(a0)			; goto Card_Leave next
+		addq.b	#2,ost_routine(a0)			; goto Card_Leave next
 		
 	.wait:
 		jmp	DisplaySprite

--- a/Objects/Yadrin.asm
+++ b/Objects/Yadrin.asm
@@ -26,7 +26,7 @@ Yad_Main:	; Routine 0
 		move.b	#$14,ost_width(a0)
 		move.l	#Map_Yad,ost_mappings(a0)
 		move.w	(v_tile_yadrin).w,ost_tile(a0)
-		add.w	#tile_pal2,ost_tile(a0)
+		addi.w	#tile_pal2,ost_tile(a0)
 		move.b	#render_rel,ost_render(a0)
 		move.b	#priority_4,ost_priority(a0)
 		move.b	#$14,ost_displaywidth(a0)

--- a/Objects/_AnimateSprite.asm
+++ b/Objects/_AnimateSprite.asm
@@ -156,7 +156,7 @@ Anim_Flag_WalkRun:
 		move.b	(a2,d0.w),d0				; get animation for specified angle
 		bpl.s	.noinvert				; branch if invert flag is not set
 		ori.b	#render_xflip+render_yflip,ost_render(a0) ; x/yflip sprite
-		and.b	#$7F,d0					; remove invert flag
+		andi.b	#$7F,d0					; remove invert flag
 	.noinvert:
 		eor.b	d2,ost_render(a0)			; apply xflip from status
 

--- a/Objects/_SolidObject.asm
+++ b/Objects/_SolidObject.asm
@@ -20,11 +20,11 @@
 SolidObject:
 		tst.b	ost_render(a0)
 		bpl.w	Sol_OffScreen				; branch if object isn't on screen
-		
+
 SolidObject_SkipRender:
 		tst.w	(v_debug_active_hi).w
 		bne.s	Sol_None				; branch if debug mode is in use
-		
+
 SolidObject_SkipRenderDebug:
 		tst.b	ost_mode(a0)
 		bne.w	Sol_Stand				; branch if Sonic is already standing on object
@@ -34,16 +34,16 @@ SolidObject_SkipRenderDebug:
 		bgt.s	Sol_None				; branch if outside x hitbox
 		range_y_exact
 		bpl.s	Sol_None				; branch if outside y hitbox
-		
+
 		cmp.w	d1,d3
 		blt.w	Sol_Side				; branch if Sonic is to the side
-		
+
 		tst.w	d2
 		bmi.s	Sol_Above				; branch if Sonic is above
-		
+
 		cmpi.w	#-1,d1
 		bge.s	Sol_None				; branch if Sonic is below, but within 1px of the sides
-		
+
 Sol_Below:
 		sub.w	d3,ost_y_pos(a1)			; snap to hitbox
 		move.w	#0,ost_y_vel(a1)			; stop Sonic moving up
@@ -57,11 +57,11 @@ Sol_None:
 		beq.s	Sol_OffScreen				; branch if object isn't being pushed
 		bclr	#status_pushing_bit,ost_status(a1)	; stop pushing
 		bclr	#status_pushing_bit,ost_status(a0)
-		
+
 Sol_OffScreen:
 		moveq	#solid_none,d1				; set collision flag to none
 		rts
-		
+
 Sol_Above:
 		tst.w	ost_y_vel(a1)
 		bmi.s	Sol_None				; branch if Sonic is moving up
@@ -74,7 +74,7 @@ Sol_Above:
 		cmpi.b	#id_Roll,ost_anim(a1)
 		bne.s	.not_rolling				; branch if Sonic wasn't rolling/jumping
 		addq.b	#2,ost_mode(a0)				; set flag - Sonic hit the object rolling/jumping
-		
+
 	.not_rolling:
 		bset	#status_platform_bit,ost_status(a0)	; set object's platform flag
 		bset	#status_platform_bit,ost_status(a1)	; set Sonic standing on object flag
@@ -84,28 +84,28 @@ Sol_Above:
 		exg	a0,a1					; temporarily make Sonic the current object
 		jsr	Sonic_ResetOnFloor			; reset Sonic as if on floor
 		exg	a0,a1
-		
+
 	.exit:
 		moveq	#solid_top,d1				; set collision flag to top
 		rts
-		
+
 Sol_Side:
 		tst.w	d0
 		bmi.s	.left					; branch if Sonic is on left side
-		
+
 	.right:
 		sub.w	d1,ost_x_pos(a1)			; snap to hitbox
 		moveq	#solid_right,d1				; set collision flag to right
 		cmpi.w	#0,ost_x_vel(a1)
 		bgt.s	.away					; branch if Sonic is moving away
 		bra.s	.push
-		
+
 	.left:
 		add.w	d1,ost_x_pos(a1)			; snap to hitbox
 		moveq	#solid_left,d1				; set collision flag to left
 		tst.w	ost_x_vel(a1)
 		bmi.s	.away					; branch if Sonic is moving away
-		
+
 	.push:
 		btst	#status_air_bit,ost_status(a1)
 		bne.s	.in_air					; branch if Sonic is in the air
@@ -113,21 +113,21 @@ Sol_Side:
 		bne.s	.stop_moving				; branch if Sonic has already started pushing
 		bset	#status_pushing_bit,ost_status(a0)	; make object be pushed
 		rts
-		
+
 	.away:
 		bclr	#status_pushing_bit,ost_status(a1)
 		bclr	#status_pushing_bit,ost_status(a0)
 		rts
-		
+
 	.in_air:
 		bclr	#status_pushing_bit,ost_status(a1)
 		bclr	#status_pushing_bit,ost_status(a0)
-		
+
 	.stop_moving:
 		move.w	#0,ost_inertia(a1)
 		move.w	#0,ost_x_vel(a1)			; stop Sonic moving
 		rts
-		
+
 Sol_Stand:
 		getsonic
 		btst	#status_air_bit,ost_status(a1)
@@ -135,7 +135,7 @@ Sol_Stand:
 		range_x_sonic
 		tst	d1
 		bpl.s	Sol_Stand_Leave				; branch if Sonic is outside left/right edges
-		
+
 		range_y_exact
 		add.w	d3,ost_y_pos(a1)			; align Sonic with top of object
 		move.w	ost_x_prev(a0),d2
@@ -144,7 +144,7 @@ Sol_Stand:
 		add.w	ost_x_pos(a0),d2			; subtract previous x pos for distance in pixels moved (+ve if moved right)
 		clr.w	ost_x_prev(a0)
 		add.w	d2,ost_x_pos(a1)			; update Sonic's x position
-		
+
 	.skip_x:
 		moveq	#solid_top,d1				; set collision flag to top
 		rts
@@ -155,7 +155,7 @@ Sol_Stand_Leave:
 		clr.b	ost_mode(a0)
 		moveq	#solid_none,d1
 		rts
-		
+
 Sol_Stand_TopOnly:
 		getsonic
 		btst	#status_air_bit,ost_status(a1)
@@ -163,7 +163,7 @@ Sol_Stand_TopOnly:
 		range_x_sonic0
 		tst	d1
 		bpl.s	Sol_Stand_Leave				; branch if Sonic is outside left/right edges
-		
+
 		range_y_exact
 		add.w	d3,ost_y_pos(a1)			; align Sonic with top of object
 		move.w	ost_x_prev(a0),d2
@@ -172,17 +172,17 @@ Sol_Stand_TopOnly:
 		add.w	ost_x_pos(a0),d2			; subtract previous x pos for distance in pixels moved (+ve if moved right)
 		clr.w	ost_x_prev(a0)
 		add.w	d2,ost_x_pos(a1)			; update Sonic's x position
-		
+
 	.skip_x:
 		moveq	#solid_top,d1				; set collision flag to top
 		rts
-		
+
 Sol_Stand_SkipRange:
 		btst	#status_air_bit,ost_status(a1)
 		bne.s	Sol_Stand_Leave				; branch if Sonic jumps
 		tst	d1
 		bpl.w	Sol_Stand_Leave				; branch if Sonic is outside left/right edges
-		
+
 		add.w	d3,ost_y_pos(a1)			; align Sonic with top of object
 		move.w	ost_x_prev(a0),d2
 		beq.s	.skip_x					; branch if previous x pos is unused
@@ -190,14 +190,14 @@ Sol_Stand_SkipRange:
 		add.w	ost_x_pos(a0),d2			; subtract previous x pos for distance in pixels moved (+ve if moved right)
 		clr.w	ost_x_prev(a0)
 		add.w	d2,ost_x_pos(a1)			; update Sonic's x position
-		
+
 	.skip_x:
 		moveq	#solid_top,d1				; set collision flag to top
 		rts
-		
+
 Sol_Kill:
 		jmp	ObjectKillSonic				; Sonic dies
-		
+
 ; ---------------------------------------------------------------------------
 ; Subroutine to make an object solid, sides only
 
@@ -215,14 +215,14 @@ SolidObject_SidesOnly:
 		bne.w	Sol_None				; branch if debug mode is in use
 		getsonic
 		range_x_sonic					; get distances between Sonic (a1) and object (a0)
-		cmp.w	#0,d1
+		tst.w	d1
 		bgt.s	.exit					; branch if outside x hitbox
 		range_y_exact
 		bpl.s	.exit					; branch if outside y hitbox
-		
+
 		cmp.w	d1,d3
 		blt.w	Sol_Side				; branch if Sonic is to the side
-		
+
 	.exit:
 		moveq	#solid_none,d1				; set collision flag to none
 		rts
@@ -241,25 +241,25 @@ SolidObject_SidesOnly:
 SolidObject_TopOnly:
 		tst.b	ost_render(a0)
 		bpl.w	Sol_OffScreen				; branch if object isn't on screen
-		
+
 SolidObject_TopOnly_SkipRender:
 		tst.w	(v_debug_active_hi).w
 		bne.w	Sol_OffScreen				; branch if debug mode is in use
-		
+
 SolidObject_TopOnly_SkipRenderDebug:
 		tst.b	ost_mode(a0)
 		bne.w	Sol_Stand_TopOnly			; branch if Sonic is already standing on object
 		getsonic
 		range_x_sonic0					; get distances between Sonic (a1) and object (a0)
-		cmp.w	#0,d1
+		tst.w	d1
 		bgt.s	.exit					; branch if outside x hitbox
 		range_y_exact
 		tst.w	d3
 		bpl.s	.exit					; branch if outside y hitbox
-		
+
 		cmpi.w	#-8,d3
 		bge.w	Sol_Above				; branch if Sonic is above
-		
+
 	.exit:
 		moveq	#solid_none,d1				; set collision flag to none
 		rts
@@ -296,12 +296,12 @@ SolidObject_Heightmap:
 		bpl.w	Sol_OffScreen				; branch if object isn't on screen
 		tst.w	(v_debug_active_hi).w
 		bne.w	Sol_None				; branch if debug mode is in use
-		
+
 		getsonic
 		range_x_sonic					; get distances between Sonic (a1) and object (a0)
 		cmpi.w	#0,d1
 		bgt.w	Sol_None				; branch if outside x hitbox
-		
+
 		moveq	#0,d5
 		move.w	ost_y_pos(a1),d2
 		sub.w	ost_y_pos(a0),d2			; d2 = y dist (-ve if Sonic is above)
@@ -309,24 +309,24 @@ SolidObject_Heightmap:
 		bmi.s	.use_heightmap				; branch if Sonic is above object
 		move.b	ost_height(a0),d5			; use regular height if below
 		bra.s	.skip_heightmap
-		
+
 	.use_heightmap:
 		neg.w	d3					; make d3 +ve
 		tst.w	d4
 		bmi.s	.left_edge				; branch if outside left edge (d5 stays 0)
 		move.w	d4,d5					; d5 = x pos on object
 		lsr.w	d6,d5					; reduce precision
-		
+
 	.left_edge:
 		move.b	(a2,d5.w),d5				; get height byte from heightmap
 		andi.w	#$FF,d5
-		
+
 	.skip_heightmap:
 		sub.w	d5,d3
 		move.b	ost_height(a1),d5
 		sub.w	d5,d3					; d3 = y dist between hitbox edges (-ve if overlapping)
 		subq.w	#1,d3
-		
+
 		tst.b	ost_mode(a0)
 		bne.w	Sol_Stand_SkipRange			; branch if Sonic is already standing on object
 		tst.w	d3
@@ -338,7 +338,7 @@ SolidObject_Heightmap:
 		cmpi.w	#-1,d1
 		bge.w	Sol_None				; branch if Sonic is below, but within 1px of the sides
 		bra.w	Sol_Below
-		
+
 ; ---------------------------------------------------------------------------
 ; Subroutine to make an object solid, top only
 
@@ -359,12 +359,12 @@ SolidObject_TopOnly_Heightmap:
 		bpl.w	Sol_OffScreen				; branch if object isn't on screen
 		tst.w	(v_debug_active_hi).w
 		bne.s	.exit					; branch if debug mode is in use
-		
+
 		getsonic
 		range_x_sonic0
-		cmp.w	#0,d1
+		tst.w	d1
 		bgt.s	.exit					; branch if outside x hitbox
-		
+
 		moveq	#0,d5
 		move.w	ost_y_pos(a1),d2
 		sub.w	ost_y_pos(a0),d2			; d2 = y dist (-ve if Sonic is above)
@@ -375,7 +375,7 @@ SolidObject_TopOnly_Heightmap:
 		bmi.s	.left_edge				; branch if outside left edge (d5 stays 0)
 		move.w	d4,d5					; d5 = x pos on object
 		lsr.w	d6,d5					; reduce precision
-		
+
 	.left_edge:
 		move.b	(a2,d5.w),d5				; get height byte from heightmap
 		andi.w	#$FF,d5
@@ -383,21 +383,21 @@ SolidObject_TopOnly_Heightmap:
 		move.b	ost_height(a1),d5
 		sub.w	d5,d3					; d3 = y dist between hitbox edges (-ve if overlapping)
 		subq.w	#1,d3
-		
+
 		tst.b	ost_mode(a0)
 		bne.w	Sol_Stand_SkipRange			; branch if Sonic is already standing on object
 		tst.w	d3
 		bpl.s	.exit					; branch if outside y hitbox
-		
+
 		moveq	#-8,d5
 		cmpi.w	#$800,ost_y_vel(a1)
 		blt.s	.slow_fall				; branch if Sonic isn't falling fast
 		subq.w	#8,d5					; 16px tolerance
-		
+
 	.slow_fall:
 		cmp.w	d5,d3
 		bge.w	Sol_Above				; branch if Sonic is above
-		
+
 	.exit:
 		moveq	#solid_none,d1				; set collision flag to none
 		rts
@@ -418,7 +418,7 @@ UnSolid:
 		bclr	#status_platform_bit,ost_status(a0)
 		clr.b	ost_mode(a0)
 		bra.w	Sol_None				; stop pushing
-		
+
 UnSolid_TopOnly:
 		getsonic
 		btst	#status_platform_bit,ost_status(a0)
@@ -429,6 +429,6 @@ UnSolid_TopOnly:
 		move.b	#id_Sonic_Control,ost_routine(a1)
 		clr.b	ost_mode(a0)
 		moveq	#solid_none,d1
-		
+
 	.exit:
 		rts

--- a/Zones & Characters.asm
+++ b/Zones & Characters.asm
@@ -61,7 +61,7 @@ LoadPerZone:
 
 		movea.l	(a4)+,a1				; get pointer for OPL list
 		move.l	(a1,d4.w),(v_opl_data_ptr).w		; get pointer for actual OPL data
-		
+
 		movea.l	(a4)+,a1				; get pointer for level layout list
 		movea.l	(a1,d4.w),a1				; get pointer for actual level layout
 		lea	(v_level_layout).w,a2
@@ -535,11 +535,11 @@ LoadPerCharacter:
 
 		move.l	(a4),(v_ost_player).w			; load player object
 		move.l	(a4)+,(v_player1_ptr).w			; save pointer to player object
-		cmp.b	#id_Special,(v_gamemode).w
+		cmpi.b	#id_Special,(v_gamemode).w
 		bne.s	.not_special				; branch if not on Special Stage
 		move.l	(a4),(v_ost_player).w			; load Special Stage player object
 	.not_special:
-		lea	4(a4),a4
+		addq.w	#4,a4
 
 		move.w	(a4)+,d0
 		bmi.s	.skip_pal


### PR DESCRIPTION
The use of `add, sub, cmp,` and `and` mnemonics with immediate source operands in some of your earlier code caused me to miss a bunch of these previously. I've changed all of them to their immediate forms for consistency, in addition to optimizing many of them to addq and subq, along with performing a bunch of moveq and clr optimizations, one more absolute short jsr, and even a few tst optimizations. I also changed a couple of single line macros (saveparent and noreturn) into short macros.